### PR TITLE
Implement into_inner for all Hash types

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -36,6 +36,7 @@ serde_impl!(Hash, 20);
 
 impl HashTrait for Hash {
     type Engine = sha256::HashEngine;
+    type Inner = [u8; 20];
 
     fn engine() -> sha256::HashEngine {
         sha256::Hash::engine()
@@ -66,6 +67,10 @@ impl HashTrait for Hash {
             ret.copy_from_slice(sl);
             Ok(Hash(ret))
         }
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
     }
 }
 

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -127,6 +127,7 @@ mod tests {
             }
             let manual_hash = Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -26,7 +26,7 @@ use Error;
 
 /// Output of the Bitcoin HASH160 hash function
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Hash(pub [u8; 20]);
+pub struct Hash([u8; 20]);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -314,6 +314,7 @@ mod tests {
             engine.input(&test.input);
             let hash = Hmac::<sha256::Hash>::from_engine(engine);
             assert_eq!(&hash[..], &test.output[..]);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -145,6 +145,7 @@ impl<T: Hash> ops::Index<ops::RangeFull> for Hmac<T> {
 
 impl<T: Hash> Hash for Hmac<T> {
     type Engine = HmacEngine<T>;
+    type Inner = T::Inner;
 
     fn engine() -> HmacEngine<T> {
         HmacEngine::new(&[])
@@ -167,6 +168,10 @@ impl<T: Hash> Hash for Hmac<T> {
 
     fn from_slice(sl: &[u8]) -> Result<Hmac<T>, Error> {
         T::from_slice(sl).map(Hmac)
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0.into_inner()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,9 @@ pub trait Hash: Copy + Clone + PartialEq + Eq +
     /// any conditions.
     type Engine: HashEngine;
 
+    /// The byte array that represents the hash internally
+    type Inner;
+
     /// Construct a new engine
     fn engine() -> Self::Engine;
 
@@ -112,5 +115,8 @@ pub trait Hash: Copy + Clone + PartialEq + Eq +
     /// should be backward. For some reason Satoshi decided this should be
     /// true for `Sha256dHash`, so here we are.
     fn display_backward() -> bool { false }
+
+    /// Unwraps the hash and returns the underlying byte array
+    fn into_inner(self) -> Self::Inner;
 }
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -524,6 +524,7 @@ mod tests {
             }
             let manual_hash = ripemd160::Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -68,6 +68,7 @@ serde_impl!(Hash, 20);
 
 impl HashTrait for Hash {
     type Engine = HashEngine;
+    type Inner = [u8; 20];
 
     fn engine() -> HashEngine {
         HashEngine {
@@ -115,6 +116,10 @@ impl HashTrait for Hash {
             ret.copy_from_slice(sl);
             Ok(Hash(ret))
         }
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
     }
 }
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -58,7 +58,7 @@ impl EngineTrait for HashEngine {
 
 /// Output of the RIPEMD160 hash function
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Hash(pub [u8; 20]);
+pub struct Hash([u8; 20]);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -258,6 +258,7 @@ mod tests {
             }
             let manual_hash = sha1::Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -63,6 +63,7 @@ serde_impl!(Hash, 20);
 
 impl HashTrait for Hash {
     type Engine = HashEngine;
+    type Inner = [u8; 20];
 
     fn engine() -> HashEngine {
         HashEngine {
@@ -110,6 +111,10 @@ impl HashTrait for Hash {
             ret.copy_from_slice(sl);
             Ok(Hash(ret))
         }
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
     }
 }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -53,7 +53,7 @@ impl EngineTrait for HashEngine {
 
 /// Output of the SHA1 hash function
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Hash(pub [u8; 20]);
+pub struct Hash([u8; 20]);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -53,7 +53,7 @@ impl EngineTrait for HashEngine {
 
 /// Output of the SHA256 hash function
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Hash(pub [u8; 32]);
+pub struct Hash([u8; 32]);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -63,6 +63,7 @@ serde_impl!(Hash, 32);
 
 impl HashTrait for Hash {
     type Engine = HashEngine;
+    type Inner = [u8; 32];
 
     fn engine() -> HashEngine {
         HashEngine {
@@ -110,6 +111,10 @@ impl HashTrait for Hash {
             ret.copy_from_slice(sl);
             Ok(Hash(ret))
         }
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
     }
 }
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -330,6 +330,7 @@ mod tests {
             }
             let manual_hash = sha256::Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -20,7 +20,7 @@ use Error;
 
 /// Output of the SHA256d hash function
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct Hash(pub [u8; 32]);
+pub struct Hash([u8; 32]);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -30,6 +30,7 @@ serde_impl!(Hash, 32);
 
 impl HashTrait for Hash {
     type Engine = sha256::HashEngine;
+    type Inner = [u8; 32];
 
     fn engine() -> sha256::HashEngine {
         sha256::Hash::engine()
@@ -64,6 +65,10 @@ impl HashTrait for Hash {
 
     fn display_backward() -> bool {
         true
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
     }
 }
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -117,6 +117,7 @@ input: &'static str,
             }
             let manual_hash = sha256d::Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -58,7 +58,7 @@ impl EngineTrait for HashEngine {
 }
 
 /// Output of the SHA256 hash function
-pub struct Hash(pub [u8; 64]);
+pub struct Hash([u8; 64]);
 
 impl Copy for Hash {}
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -387,6 +387,7 @@ mod tests {
             }
             let manual_hash = sha512::Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
+            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -86,6 +86,7 @@ serde_impl!(Hash, 64);
 
 impl HashTrait for Hash {
     type Engine = HashEngine;
+    type Inner = [u8; 64];
 
     fn engine() -> HashEngine {
         HashEngine {
@@ -137,6 +138,10 @@ impl HashTrait for Hash {
             ret.copy_from_slice(sl);
             Ok(Hash(ret))
         }
+    }
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
     }
 }
 


### PR DESCRIPTION
Even though the inner value is public for all hash types except `Hmac` it's better to have a well defined common interface for getting the underlying data structure.

I'd propose to make the inner values private to enforce usage of `into_inner(self)`.

## TODO:
- [x] Make inner structs private
- [ ] Tests