### PR TITLE
Add fuzztarget support for sha256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 [features]
 default = []
 unstable = []  # for benchmarking
+fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noops, DON'T USE THIS
 
 [dev-dependencies]
 serde_test = "1.0"


### PR DESCRIPTION
This doesn't add support for ripemd or sha256, which we probably
should do at some point, but this is what's required for matching
current rust-lightning/rust-bitcoin fuzztarget support.