### PR TITLE
Add SHA-512/Ripemd-160 fuzztargets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,5 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo test --verbose --features "serde"
+  - cargo build --verbose --features "fuzztarget"
   - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -166,7 +166,7 @@ impl io::Write for HashEngine {
     #[cfg(feature = "fuzztarget")]
     fn write(&mut self, inp: &[u8]) -> io::Result<usize> {
         for c in inp {
-            self.buffer[0] ^= c;
+            self.buffer[0] ^= *c;
         }
         Ok(inp.len())
     }


### PR DESCRIPTION
I didn't realize rust-bitcoin had a sha-512 stub. Also include Ripemd-160 stub.