### PR TITLE
[Discussion Needed] Allow constructing Hashes from underlying byte array

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -73,6 +73,10 @@ impl HashTrait for Hash {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
 }
 
 #[cfg(test)]

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -179,6 +179,10 @@ impl<T: Hash> Hash for Hmac<T> {
     fn into_inner(self) -> Self::Inner {
         self.0.into_inner()
     }
+
+    fn from_inner(inner: T::Inner) -> Self {
+        Hmac(T::from_inner(inner))
+    }
 }
 
 #[cfg(feature="serde")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,4 +118,7 @@ pub trait Hash: Copy + Clone + PartialEq + Eq +
 
     /// Unwraps the hash and returns the underlying byte array
     fn into_inner(self) -> Self::Inner;
+
+    /// Constructs a hash from the underlying byte array
+    fn from_inner(inner: Self::Inner) -> Self;
 }

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -138,6 +138,10 @@ impl HashTrait for Hash {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
 }
 
 macro_rules! round(

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -117,6 +117,10 @@ impl HashTrait for Hash {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
 }
 
 impl io::Write for HashEngine {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -131,6 +131,10 @@ impl HashTrait for Hash {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
 }
 
 impl io::Write for HashEngine {

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -71,6 +71,10 @@ impl HashTrait for Hash {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
 }
 
 #[cfg(test)]

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -160,6 +160,10 @@ impl HashTrait for Hash {
     fn into_inner(self) -> Self::Inner {
         self.0
     }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner)
+    }
 }
 
 impl io::Write for HashEngine {


### PR DESCRIPTION
With https://github.com/rust-bitcoin/bitcoin_hashes/pull/14 merged, there is no longer a direct way to construct Hashes from an underlying byte array. This reintroduces a way to do so. This also allows for a more efficient implementation of `impl<D: Decoder> Decodable<D> for sha256d::Hash`.

Needs much discussion because of concerns brought up in https://github.com/rust-bitcoin/bitcoin_hashes/issues/10.