### PR TITLE
Avoid refering to file-specific constants in write_impl macro

### DIFF
--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -78,6 +78,10 @@ impl<T: Hash> HashEngine for HmacEngine<T> {
     fn midstate(&self) -> Self::MidState {
         self.iengine.midstate()
     }
+
+    fn block_size() -> usize {
+        T::block_size()
+    }
 }
 
 impl<T: Hash> io::Write for HmacEngine<T> {
@@ -166,10 +170,6 @@ impl<T: Hash> Hash for Hmac<T> {
 
     fn len() -> usize {
         T::len()
-    }
-
-    fn block_size() -> usize {
-        T::block_size()
     }
 
     fn from_slice(sl: &[u8]) -> Result<Hmac<T>, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,9 @@ pub trait HashEngine: Clone + io::Write {
     /// used directly unless you really know what you're doing.
     fn midstate(&self) -> Self::MidState;
 
+    /// Length of the hash's internal block size, in bytes
+    fn block_size() -> usize;
+
     /// Add data to the hash engine without any error return type to deal with
     #[inline(always)]
     fn input(&mut self, data: &[u8]) {
@@ -97,7 +100,7 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     fn len() -> usize;
 
     /// Length of the hash's internal block size, in bytes
-    fn block_size() -> usize;
+    fn block_size() -> usize { Self::Engine::block_size() }
 
     /// Copies a byte slice into a hash object
     fn from_slice(sl: &[u8]) -> Result<Self, Error>;

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -62,6 +62,10 @@ impl EngineTrait for HashEngine {
         ret.copy_from_slice(&self.buffer[..20]);
         ret
     }
+
+    fn block_size() -> usize {
+        64
+    }
 }
 
 /// Output of the RIPEMD160 hash function
@@ -119,10 +123,6 @@ impl HashTrait for Hash {
 
     fn len() -> usize {
         20
-    }
-
-    fn block_size() -> usize {
-        64
     }
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -49,6 +49,10 @@ impl EngineTrait for HashEngine {
         BigEndian::write_u32_into(&self.h, &mut ret);
         ret
     }
+
+    fn block_size() -> usize {
+        64
+    }
 }
 
 /// Output of the SHA1 hash function
@@ -98,10 +102,6 @@ impl HashTrait for Hash {
 
     fn len() -> usize {
         20
-    }
-
-    fn block_size() -> usize {
-        64
     }
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -57,6 +57,10 @@ impl EngineTrait for HashEngine {
         ret.copy_from_slice(&self.buffer[..32]);
         ret
     }
+
+    fn block_size() -> usize {
+        64
+    }
 }
 
 /// Output of the SHA256 hash function
@@ -112,10 +116,6 @@ impl HashTrait for Hash {
 
     fn len() -> usize {
         32
-    }
-
-    fn block_size() -> usize {
-        64
     }
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -65,6 +65,10 @@ impl EngineTrait for HashEngine {
         ret.copy_from_slice(&self.buffer[..64]);
         ret
     }
+
+    fn block_size() -> usize {
+        128
+    }
 }
 
 /// Output of the SHA256 hash function
@@ -169,10 +173,6 @@ impl HashTrait for Hash {
 
     fn len() -> usize {
         64
-    }
-
-    fn block_size() -> usize {
-        128
     }
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,13 +94,13 @@ macro_rules! write_impl(
 
             #[cfg(not(feature = "fuzztarget"))]
             fn write(&mut self, inp: &[u8]) -> ::std::io::Result<usize> {
-                let buf_idx = self.length % BLOCK_SIZE;
-                let rem_len = BLOCK_SIZE - buf_idx;
+                let buf_idx = self.length % <Self as ::HashEngine>::block_size();
+                let rem_len = <Self as ::HashEngine>::block_size() - buf_idx;
                 let write_len = ::std::cmp::min(rem_len, inp.len());
 
                 self.buffer[buf_idx..buf_idx + write_len].copy_from_slice(&inp[..write_len]);
                 self.length += write_len;
-                if self.length % BLOCK_SIZE == 0 {
+                if self.length % <Self as ::HashEngine>::block_size() == 0 {
                     self.process_block();
                 }
 


### PR DESCRIPTION
This also adds a block_size to HashEngine, which makes sense since
the engine is really what has the block size, not the hash.