### PR TITLE
Bump rustc version to 1.22.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
   - stable
   - beta
   - nightly
-  - 1.14.0
+  - 1.22.0
 
 before_install:
   - sudo apt-get -qq update


### PR DESCRIPTION
Bumps `rustc` version according to https://github.com/rust-bitcoin/rust-bitcoin/pull/210