### PR TITLE
Deserialize into owned String for human-readable deserializer

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -135,7 +135,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn ripemd_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 20] = [
             0x13, 0x20, 0x72, 0xdf,
@@ -147,8 +147,7 @@ mod tests {
 
         let hash = hash160::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
-        assert_de_tokens(&hash.readable(), &[Token::BorrowedStr("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
+        assert_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
     }
 }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -327,7 +327,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn hmac_sha512_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 64] = [
             0x8b, 0x41, 0xe1, 0xb7, 0x8a, 0xd1, 0x15, 0x21,
@@ -342,16 +342,9 @@ mod tests {
 
         let hash = Hmac::<sha512::Hash>::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(
+        assert_tokens(
             &hash.readable(),
             &[Token::Str(
-                "8b41e1b78ad11521113c52ff182a1b8e0a195754aa527fcd00a411620b46f20f\
-                 fffb8088ccf85497121ad4499e0845b876f6dd6640088a2f0b2d8a600bdf4c0c"
-            )],
-        );
-        assert_de_tokens(
-            &hash.readable(),
-            &[Token::BorrowedStr(
                 "8b41e1b78ad11521113c52ff182a1b8e0a195754aa527fcd00a411620b46f20f\
                  fffb8088ccf85497121ad4499e0845b876f6dd6640088a2f0b2d8a600bdf4c0c"
             )],

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -518,7 +518,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn ripemd_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 20] = [
             0x13, 0x20, 0x72, 0xdf,
@@ -530,8 +530,7 @@ mod tests {
 
         let hash = ripemd160::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
-        assert_de_tokens(&hash.readable(), &[Token::BorrowedStr("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
+        assert_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
     }
 }
 

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -21,8 +21,8 @@ macro_rules! serde_impl(
                 use hex::FromHex;
 
                 if d.is_human_readable() {
-                    let sl: &str = ::serde::Deserialize::deserialize(d)?;
-                    $t::from_hex(sl).map_err(D::Error::custom)
+                    let sl: String = ::serde::Deserialize::deserialize(d)?;
+                    $t::from_hex(&sl).map_err(D::Error::custom)
                 } else {
                     let sl: &[u8] = ::serde::Deserialize::deserialize(d)?;
                     if sl.len() != $t::len() {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -236,7 +236,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn sha1_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 20] = [
             0x13, 0x20, 0x72, 0xdf,
@@ -248,8 +248,7 @@ mod tests {
 
         let hash = sha1::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
-        assert_de_tokens(&hash.readable(), &[Token::BorrowedStr("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
+        assert_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
     }
 }
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -348,7 +348,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn sha256_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 32] = [
             0xef, 0x53, 0x7f, 0x25, 0xc8, 0x95, 0xbf, 0xa7,
@@ -359,8 +359,7 @@ mod tests {
 
         let hash = sha256::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(&hash.readable(), &[Token::Str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")]);
-        assert_de_tokens(&hash.readable(), &[Token::BorrowedStr("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")]);
+        assert_tokens(&hash.readable(), &[Token::Str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")]);
     }
 }
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -125,7 +125,7 @@ input: &'static str,
     #[cfg(feature="serde")]
     #[test]
     fn sha256_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 32] = [
             0xef, 0x53, 0x7f, 0x25, 0xc8, 0x95, 0xbf, 0xa7,
@@ -136,8 +136,7 @@ input: &'static str,
 
         let hash = sha256d::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(&hash.readable(), &[Token::Str("6cfb35868c4465b7c289d7d5641563aa973db6a929655282a7bf95c8257f53ef")]);
-        assert_de_tokens(&hash.readable(), &[Token::BorrowedStr("6cfb35868c4465b7c289d7d5641563aa973db6a929655282a7bf95c8257f53ef")]);
+        assert_tokens(&hash.readable(), &[Token::Str("6cfb35868c4465b7c289d7d5641563aa973db6a929655282a7bf95c8257f53ef")]);
     }
 }
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -409,7 +409,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn sha512_serde() {
-        use serde_test::{Configure, Token, assert_tokens, assert_ser_tokens, assert_de_tokens};
+        use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 64] = [
             0x8b, 0x41, 0xe1, 0xb7, 0x8a, 0xd1, 0x15, 0x21,
@@ -424,16 +424,9 @@ mod tests {
 
         let hash = sha512::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
-        assert_ser_tokens(
+        assert_tokens(
             &hash.readable(),
             &[Token::Str(
-                "8b41e1b78ad11521113c52ff182a1b8e0a195754aa527fcd00a411620b46f20f\
-                 fffb8088ccf85497121ad4499e0845b876f6dd6640088a2f0b2d8a600bdf4c0c"
-            )],
-        );
-        assert_de_tokens(
-            &hash.readable(),
-            &[Token::BorrowedStr(
                 "8b41e1b78ad11521113c52ff182a1b8e0a195754aa527fcd00a411620b46f20f\
                  fffb8088ccf85497121ad4499e0845b876f6dd6640088a2f0b2d8a600bdf4c0c"
             )],


### PR DESCRIPTION
- Modify tests to properly roundtrip for serde (de)serialization.

This blocks https://github.com/rust-bitcoin/rust-bitcoin/pull/215