### PR TITLE
Remove extraneous block_size method from Hash trait

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -56,10 +56,6 @@ impl HashTrait for Hash {
         20
     }
 
-    fn block_size() -> usize {
-        64
-    }
-
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 20 {
             Err(Error::InvalidLength(Self::len(), sl.len()))

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -40,7 +40,7 @@ impl<T: Hash> HmacEngine<T> {
     /// Construct a new keyed HMAC with the given key. We only support underlying hashes
     /// whose block sizes are ≤ 128 bytes; larger hashes will result in panics.
     pub fn new(key: &[u8]) -> HmacEngine<T> {
-        debug_assert!(T::block_size() <= 128);
+        debug_assert!(T::Engine::block_size() <= 128);
 
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
@@ -49,7 +49,7 @@ impl<T: Hash> HmacEngine<T> {
             oengine: <T as Hash>::engine(),
         };
 
-        if key.len() > <T as Hash>::block_size() {
+        if key.len() > T::Engine::block_size() {
             let hash = <T as Hash>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(&hash[..]) {
                 *b_i ^= *b_h;
@@ -66,8 +66,8 @@ impl<T: Hash> HmacEngine<T> {
             }
         };
 
-        HashEngine::input(&mut ret.iengine, &ipad[..T::block_size()]);
-        HashEngine::input(&mut ret.oengine, &opad[..T::block_size()]);
+        HashEngine::input(&mut ret.iengine, &ipad[..T::Engine::block_size()]);
+        HashEngine::input(&mut ret.oengine, &opad[..T::Engine::block_size()]);
         ret
     }
 }
@@ -80,7 +80,7 @@ impl<T: Hash> HashEngine for HmacEngine<T> {
     }
 
     fn block_size() -> usize {
-        T::block_size()
+        T::Engine::block_size()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,6 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     /// Length of the hash, in bytes
     fn len() -> usize;
 
-    /// Length of the hash's internal block size, in bytes
-    fn block_size() -> usize { Self::Engine::block_size() }
-
     /// Copies a byte slice into a hash object
     fn from_slice(sl: &[u8]) -> Result<Self, Error>;
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -50,10 +50,6 @@ impl HashTrait for Hash {
         32
     }
 
-    fn block_size() -> usize {
-        64
-    }
-
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 32 {
             Err(Error::InvalidLength(Self::len(), sl.len()))


### PR DESCRIPTION
Since `HashEngine` already has a `block_size` method, and each `Hash` has its corresponding engine under `T::Engine`, we don't need a `block_size` method on `Hash`