### PR TITLE
Use associated constants for LEN and BLOCK_SIZE

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -52,13 +52,11 @@ impl HashTrait for Hash {
         Hash(ret)
     }
 
-    fn len() -> usize {
-        20
-    }
+    const LEN: usize = 20;
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 20 {
-            Err(Error::InvalidLength(Self::len(), sl.len()))
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         } else {
             let mut ret = [0; 20];
             ret.copy_from_slice(sl);

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -56,10 +56,6 @@ impl HashTrait for Hash {
         20
     }
 
-    fn block_size() -> usize {
-        64
-    }
-
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 20 {
             Err(Error::InvalidLength(Self::len(), sl.len()))

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -45,7 +45,7 @@ impl<'a, T: Hash> FromHex<'a> for T {
         }
 
         let mut vec = Vec::<u8>::from_hex(s)?;
-        if Self::display_backward() {
+        if Self::DISPLAY_BACKWARD {
             vec.reverse();
         }
         Self::from_slice(&vec)

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -40,8 +40,8 @@ impl<T: fmt::LowerHex> ToHex for T {
 impl<'a, T: Hash> FromHex<'a> for T {
     /// Parses a hex string as a hash object
     fn from_hex(s: &str) -> Result<Self, Error> {
-        if s.len() != 2 * Self::len() {
-            return Err(Error::InvalidLength(2 * Self::len(), s.len()));
+        if s.len() != 2 * Self::LEN {
+            return Err(Error::InvalidLength(2 * Self::LEN, s.len()));
         }
 
         let mut vec = Vec::<u8>::from_hex(s)?;

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -40,7 +40,7 @@ impl<T: Hash> HmacEngine<T> {
     /// Construct a new keyed HMAC with the given key. We only support underlying hashes
     /// whose block sizes are ≤ 128 bytes; larger hashes will result in panics.
     pub fn new(key: &[u8]) -> HmacEngine<T> {
-        debug_assert!(T::Engine::block_size() <= 128);
+        debug_assert!(T::Engine::BLOCK_SIZE <= 128);
 
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
@@ -49,7 +49,7 @@ impl<T: Hash> HmacEngine<T> {
             oengine: <T as Hash>::engine(),
         };
 
-        if key.len() > T::Engine::block_size() {
+        if key.len() > T::Engine::BLOCK_SIZE {
             let hash = <T as Hash>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(&hash[..]) {
                 *b_i ^= *b_h;
@@ -66,8 +66,8 @@ impl<T: Hash> HmacEngine<T> {
             }
         };
 
-        HashEngine::input(&mut ret.iengine, &ipad[..T::Engine::block_size()]);
-        HashEngine::input(&mut ret.oengine, &opad[..T::Engine::block_size()]);
+        HashEngine::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
+        HashEngine::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
         ret
     }
 }
@@ -79,9 +79,7 @@ impl<T: Hash> HashEngine for HmacEngine<T> {
         self.iengine.midstate()
     }
 
-    fn block_size() -> usize {
-        T::Engine::block_size()
-    }
+    const BLOCK_SIZE: usize = T::Engine::BLOCK_SIZE;
 }
 
 impl<T: Hash> io::Write for HmacEngine<T> {
@@ -168,9 +166,7 @@ impl<T: Hash> Hash for Hmac<T> {
         Hmac(ohash)
     }
 
-    fn len() -> usize {
-        T::len()
-    }
+    const LEN: usize = T::LEN;
 
     fn from_slice(sl: &[u8]) -> Result<Hmac<T>, Error> {
         T::from_slice(sl).map(Hmac)

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -40,7 +40,7 @@ impl<T: Hash> HmacEngine<T> {
     /// Construct a new keyed HMAC with the given key. We only support underlying hashes
     /// whose block sizes are ≤ 128 bytes; larger hashes will result in panics.
     pub fn new(key: &[u8]) -> HmacEngine<T> {
-        debug_assert!(T::block_size() <= 128);
+        debug_assert!(T::Engine::block_size() <= 128);
 
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
@@ -49,7 +49,7 @@ impl<T: Hash> HmacEngine<T> {
             oengine: <T as Hash>::engine(),
         };
 
-        if key.len() > <T as Hash>::block_size() {
+        if key.len() > T::Engine::block_size() {
             let hash = <T as Hash>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(&hash[..]) {
                 *b_i ^= *b_h;
@@ -66,8 +66,8 @@ impl<T: Hash> HmacEngine<T> {
             }
         };
 
-        HashEngine::input(&mut ret.iengine, &ipad[..T::block_size()]);
-        HashEngine::input(&mut ret.oengine, &opad[..T::block_size()]);
+        HashEngine::input(&mut ret.iengine, &ipad[..T::Engine::block_size()]);
+        HashEngine::input(&mut ret.oengine, &opad[..T::Engine::block_size()]);
         ret
     }
 }
@@ -80,7 +80,7 @@ impl<T: Hash> HashEngine for HmacEngine<T> {
     }
 
     fn block_size() -> usize {
-        T::block_size()
+        T::Engine::block_size()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     /// Flag indicating whether user-visible serializations of this hash
     /// should be backward. For some reason Satoshi decided this should be
     /// true for `Sha256dHash`, so here we are.
-    fn display_backward() -> bool { false }
+    const DISPLAY_BACKWARD: bool = false;
 
     /// Unwraps the hash and returns the underlying byte array
     fn into_inner(self) -> Self::Inner;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub trait HashEngine: Clone + io::Write {
     fn midstate(&self) -> Self::MidState;
 
     /// Length of the hash's internal block size, in bytes
-    fn block_size() -> usize;
+    const BLOCK_SIZE: usize;
 
     /// Add data to the hash engine without any error return type to deal with
     #[inline(always)]
@@ -98,7 +98,7 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     fn from_engine(e: Self::Engine) -> Self;
 
     /// Length of the hash, in bytes
-    fn len() -> usize;
+    const LEN: usize;
 
     /// Copies a byte slice into a hash object
     fn from_slice(sl: &[u8]) -> Result<Self, Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,6 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     /// Length of the hash, in bytes
     fn len() -> usize;
 
-    /// Length of the hash's internal block size, in bytes
-    fn block_size() -> usize { Self::Engine::block_size() }
-
     /// Copies a byte slice into a hash object
     fn from_slice(sl: &[u8]) -> Result<Self, Error>;
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -63,9 +63,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    fn block_size() -> usize {
-        64
-    }
+    const BLOCK_SIZE: usize = 64;
 }
 
 /// Output of the RIPEMD160 hash function
@@ -121,13 +119,11 @@ impl HashTrait for Hash {
         Hash(res)
     }
 
-    fn len() -> usize {
-        20
-    }
+    const LEN: usize = 20;
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 20 {
-            Err(Error::InvalidLength(Self::len(), sl.len()))
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         } else {
             let mut ret = [0; 20];
             ret.copy_from_slice(sl);

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -25,7 +25,7 @@ macro_rules! serde_impl(
                     $t::from_hex(sl).map_err(D::Error::custom)
                 } else {
                     let sl: &[u8] = ::serde::Deserialize::deserialize(d)?;
-                    if sl.len() != $t::len() {
+                    if sl.len() != $t::LEN {
                         Err(D::Error::invalid_length(sl.len(), &stringify!($len)))
                     } else {
                         let mut ret = [0; $len];

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -50,9 +50,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    fn block_size() -> usize {
-        64
-    }
+    const BLOCK_SIZE: usize = 64;
 }
 
 /// Output of the SHA1 hash function
@@ -100,13 +98,11 @@ impl HashTrait for Hash {
         Hash(e.midstate())
     }
 
-    fn len() -> usize {
-        20
-    }
+    const LEN: usize = 20;
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 20 {
-            Err(Error::InvalidLength(Self::len(), sl.len()))
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         } else {
             let mut ret = [0; 20];
             ret.copy_from_slice(sl);

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -58,9 +58,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    fn block_size() -> usize {
-        64
-    }
+    const BLOCK_SIZE: usize = 64;
 }
 
 /// Output of the SHA256 hash function
@@ -114,13 +112,11 @@ impl HashTrait for Hash {
         Hash(e.midstate())
     }
 
-    fn len() -> usize {
-        32
-    }
+    const LEN: usize = 32;
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 32 {
-            Err(Error::InvalidLength(Self::len(), sl.len()))
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         } else {
             let mut ret = [0; 32];
             ret.copy_from_slice(sl);

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -50,10 +50,6 @@ impl HashTrait for Hash {
         32
     }
 
-    fn block_size() -> usize {
-        64
-    }
-
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 32 {
             Err(Error::InvalidLength(Self::len(), sl.len()))

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -46,13 +46,11 @@ impl HashTrait for Hash {
         Hash(ret)
     }
 
-    fn len() -> usize {
-        32
-    }
+    const LEN: usize = 32;
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 32 {
-            Err(Error::InvalidLength(Self::len(), sl.len()))
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         } else {
             let mut ret = [0; 32];
             ret.copy_from_slice(sl);

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -58,9 +58,7 @@ impl HashTrait for Hash {
         }
     }
 
-    fn display_backward() -> bool {
-        true
-    }
+    const DISPLAY_BACKWARD: bool = true;
 
     fn into_inner(self) -> Self::Inner {
         self.0

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -66,9 +66,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    fn block_size() -> usize {
-        128
-    }
+    const BLOCK_SIZE: usize = 128;
 }
 
 /// Output of the SHA256 hash function
@@ -171,13 +169,11 @@ impl HashTrait for Hash {
         Hash(hash)
     }
 
-    fn len() -> usize {
-        64
-    }
+    const LEN: usize = 64;
 
     fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
         if sl.len() != 64 {
-            Err(Error::InvalidLength(Self::len(), sl.len()))
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
         } else {
             let mut ret = [0; 64];
             ret.copy_from_slice(sl);

--- a/src/util.rs
+++ b/src/util.rs
@@ -94,13 +94,13 @@ macro_rules! write_impl(
 
             #[cfg(not(feature = "fuzztarget"))]
             fn write(&mut self, inp: &[u8]) -> ::std::io::Result<usize> {
-                let buf_idx = self.length % <Self as ::HashEngine>::block_size();
-                let rem_len = <Self as ::HashEngine>::block_size() - buf_idx;
+                let buf_idx = self.length % <Self as ::HashEngine>::BLOCK_SIZE;
+                let rem_len = <Self as ::HashEngine>::BLOCK_SIZE - buf_idx;
                 let write_len = ::std::cmp::min(rem_len, inp.len());
 
                 self.buffer[buf_idx..buf_idx + write_len].copy_from_slice(&inp[..write_len]);
                 self.length += write_len;
-                if self.length % <Self as ::HashEngine>::block_size() == 0 {
+                if self.length % <Self as ::HashEngine>::BLOCK_SIZE == 0 {
                     self.process_block();
                 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,7 +26,7 @@ macro_rules! hex_fmt_impl(
         impl ::std::fmt::$imp for $ty {
             fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
                 use hex::{format_hex, format_hex_reverse};
-                if $ty::display_backward() {
+                if $ty::DISPLAY_BACKWARD {
                     format_hex_reverse(&self.0, f)
                 } else {
                     format_hex(&self.0, f)


### PR DESCRIPTION
Explanation for 7b64c50:

> Since `HashEngine` already has a `block_size` method, and each `Hash` has its corresponding engine under `T::Engine`, we don't need a `block_size` method on `Hash`