### PR TITLE
Bump to 0.3.0 and update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.3.0 - 2019-01-23
+
+* Bump minimum required rustc version to 1.22.0
+* Fixed serde deserialization into owned string that previously caused panics
+  when doing round-trip (de)serialization
+* `HashEngine::block_size()` and `Hash::len()` are now associated constants
+  `HashEngine::BLOCK_SIZE` and `Hash::LEN`
+* Removed `block_size()` method from `Hash` trait. It is still available as
+  `<T as Hash>::Engine::BLOCK_SIZE`
 
 # 0.2.0 - 2019-01-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 description = "Hash functions used by rust-bitcoin which support rustc 1.14.0"


### PR DESCRIPTION
After this release, `rust-bitcoin` will be able to successfully integrate with `bitcoin_hashes`.

@apoelstra Please publish to cargo after this gets merged.