### PR TITLE
Test builds using cargo-web on Travis to ensure they don't break

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ script:
   - cargo test --verbose
   - cargo test --verbose --features "serde"
   - cargo build --verbose --features "fuzztarget"
+  - if [ "$(rustup show | grep default | grep beta)" != "" ]; then cargo install --force cargo-web && cargo web build --target=asmjs-unknown-emscripten && cargo web test --target=asmjs-unknown-emscripten --nodejs; fi
   - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi


### PR DESCRIPTION
I didn't actually test if this thing works, but it claims to run the tests and they claim to pass, so at least we can see if things fail to compile with cargo-web in the future. I spent a bit of time fighting with wasm_pack and didn't get anywhere, it appears to require wasm-targeted crates entirely. Given the dependency tree on cargo web and it downloading the emscripten binaries (!) I woulnd't recommend anyone actually use this, but at least its there.