### PR TITLE
Tagged SHA256 hashes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,10 @@ pub mod hmac;
 pub mod ripemd160;
 pub mod sha1;
 pub mod sha256;
-pub mod sha512;
 pub mod sha256d;
+pub mod sha256t;
 pub mod siphash24;
+pub mod sha512;
 pub mod cmp;
 
 use core::{borrow, fmt, hash, ops};

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -152,3 +152,34 @@ impl<'de, T: Tag> ::serde::Deserialize<'de> for Hash<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ::{Hash, sha256, sha256t};
+    use ::hex::ToHex;
+
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]
+    pub struct TestHashTag;
+
+    impl sha256t::Tag for TestHashTag {
+        fn engine() -> sha256::HashEngine {
+            // The TapRoot TapLeaf midstate.
+            let midstate = sha256::Midstate::from_inner([
+               156, 224, 228, 230, 124, 17, 108, 57, 56, 179, 202, 242, 195, 15, 80, 137, 211, 243,
+               147, 108, 71, 99, 110, 96, 125, 179, 62, 234, 221, 198, 240, 201,
+            ]);
+            sha256::HashEngine::from_midstate(midstate, 64)
+        }
+    }
+
+    /// A hash tagged with `$name`.
+    pub type TestHash = sha256t::Hash<TestHashTag>;
+
+    #[test]
+    fn test_sha256t() {
+       assert_eq!(
+           TestHash::hash(&[0]).to_hex(),
+           "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
+       );
+    }
+}

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -1,0 +1,148 @@
+// Bitcoin Hashes Library
+// Written in 2019 by
+//   The rust-bitcoin developers.
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! # SHA256t (tagged SHA256)
+
+use core::marker::PhantomData;
+
+use sha256;
+use Hash as HashTrait;
+#[allow(unused)]
+use Error;
+
+/// Trait representing a tag that can be used as a context for SHA256t hashes.
+pub trait Tag: Copy + Ord + Default + ::core::hash::Hash {
+    /// Returns a hash engine that is pre-tagged and is ready
+    /// to be used for the data.
+    fn engine() -> sha256::HashEngine;
+}
+
+/// Output of the SHA256t hash function.
+#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+pub struct Hash<T: Tag>([u8; 32], PhantomData<T>);
+
+hex_fmt_impl!(Debug, Hash, T:Tag);
+hex_fmt_impl!(Display, Hash, T:Tag);
+hex_fmt_impl!(LowerHex, Hash, T:Tag);
+index_impl!(Hash, T:Tag);
+borrow_slice_impl!(Hash, T:Tag);
+
+impl<T: Tag> HashTrait for Hash<T> {
+    type Engine = sha256::HashEngine;
+    type Inner = [u8; 32];
+
+    fn engine() -> sha256::HashEngine {
+        T::engine()
+    }
+
+    fn from_engine(e: sha256::HashEngine) -> Hash<T> {
+        Hash::from_inner(sha256::Hash::from_engine(e).into_inner())
+    }
+
+    const LEN: usize = 32;
+
+    fn from_slice(sl: &[u8]) -> Result<Hash<T>, Error> {
+        if sl.len() != 32 {
+            Err(Error::InvalidLength(Self::LEN, sl.len()))
+        } else {
+            let mut ret = [0; 32];
+            ret.copy_from_slice(sl);
+            Ok(Hash::from_inner(ret))
+        }
+    }
+
+    // NOTE! If this is changed, please make sure the serde serialization is still correct.
+    const DISPLAY_BACKWARD: bool = true;
+
+    fn into_inner(self) -> Self::Inner {
+        self.0
+    }
+
+    fn from_inner(inner: Self::Inner) -> Self {
+        Hash(inner, PhantomData)
+    }
+}
+
+#[cfg(feature="serde")]
+impl<T: Tag> ::serde::Serialize for Hash<T> {
+    fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use ::hex::ToHex;
+        if s.is_human_readable() {
+            s.serialize_str(&self.to_hex())
+        } else {
+            s.serialize_bytes(&self[..])
+        }
+    }
+}
+
+#[cfg(feature="serde")]
+impl<'de, T: Tag> ::serde::Deserialize<'de> for Hash<T> {
+    fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<Hash<T>, D::Error> {
+        use ::hex::FromHex;
+
+        if d.is_human_readable() {
+            struct HexVisitor;
+
+            impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+                type Value = Hash<T>;
+
+                fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    formatter.write_str("an ASCII hex string")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: ::serde::de::Error,
+                {
+                    if let Ok(hex) = ::std::str::from_utf8(v) {
+                        Hash::<T>::from_hex(hex).map_err(E::custom)
+                    } else {
+                        return Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self));
+                    }
+                }
+
+                fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+                where
+                    E: ::serde::de::Error,
+                {
+                    Hash::<T>::from_hex(v).map_err(E::custom)
+                }
+            }
+
+            d.deserialize_str(HexVisitor)
+        } else {
+            struct BytesVisitor;
+
+            impl<'de> ::serde::de::Visitor<'de> for BytesVisitor {
+                type Value = Hash<T>;
+
+                fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    formatter.write_str("a bytestring")
+                }
+
+                fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+                where
+                    E: ::serde::de::Error,
+                {
+                    Hash::<T>::from_slice(v).map_err(|_| {
+                        // from_slice only errors on incorrect length
+                        E::invalid_length(v.len(), &"32")
+                    })
+                }
+            }
+
+            d.deserialize_bytes(BytesVisitor)
+        }
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,10 +26,13 @@ macro_rules! circular_lshift64 (
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`
 macro_rules! hex_fmt_impl(
     ($imp:ident, $ty:ident) => (
-        impl $crate::core::fmt::$imp for $ty {
+        hex_fmt_impl!($imp, $ty, );
+    );
+    ($imp:ident, $ty:ident, $($gen:ident: $gent:ident),*) => (
+        impl<$($gen: $gent),*> $crate::core::fmt::$imp for $ty<$($gen),*> {
             fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
                 use $crate::hex::{format_hex, format_hex_reverse};
-                if $ty::DISPLAY_BACKWARD {
+                if $ty::<$($gen),*>::DISPLAY_BACKWARD {
                     format_hex_reverse(&self.0, f)
                 } else {
                     format_hex(&self.0, f)
@@ -42,36 +45,39 @@ macro_rules! hex_fmt_impl(
 /// Adds `core::ops::Index` trait implementation to a given type `$ty`
 #[macro_export]
 macro_rules! index_impl(
-    ($ty:ty) => (
-        impl $crate::core::ops::Index<usize> for $ty {
+    ($ty:ident) => (
+        index_impl!($ty, );
+    );
+    ($ty:ident, $($gen:ident: $gent:ident),*) => (
+        impl<$($gen: $gent),*> $crate::core::ops::Index<usize> for $ty<$($gen),*> {
             type Output = u8;
             fn index(&self, index: usize) -> &u8 {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::Range<usize>> for $ty {
+        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::Range<usize>> for $ty<$($gen),*> {
             type Output = [u8];
             fn index(&self, index: $crate::core::ops::Range<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::RangeFrom<usize>> for $ty {
+        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::RangeFrom<usize>> for $ty<$($gen),*> {
             type Output = [u8];
             fn index(&self, index: $crate::core::ops::RangeFrom<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::RangeTo<usize>> for $ty {
+        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::RangeTo<usize>> for $ty<$($gen),*> {
             type Output = [u8];
             fn index(&self, index: $crate::core::ops::RangeTo<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::RangeFull> for $ty {
+        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::RangeFull> for $ty<$($gen),*> {
             type Output = [u8];
             fn index(&self, index: $crate::core::ops::RangeFull) -> &[u8] {
                 &self.0[index]
@@ -83,20 +89,23 @@ macro_rules! index_impl(
 /// Adds slicing traits implementations to a given type `$ty`
 #[macro_export]
 macro_rules! borrow_slice_impl(
-    ($ty:ty) => (
-        impl $crate::core::borrow::Borrow<[u8]> for $ty {
+    ($ty:ident) => (
+        borrow_slice_impl!($ty, );
+    );
+    ($ty:ident, $($gen:ident: $gent:ident),*) => (
+        impl<$($gen: $gent),*> $crate::core::borrow::Borrow<[u8]> for $ty<$($gen),*>  {
             fn borrow(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl $crate::core::convert::AsRef<[u8]> for $ty {
+        impl<$($gen: $gent),*> $crate::core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
             fn as_ref(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl $crate::core::ops::Deref for $ty {
+        impl<$($gen: $gent),*> $crate::core::ops::Deref for $ty<$($gen),*> {
             type Target = [u8];
 
             fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
Introducing a new `SHA256t` hash type that works as a tagged hash. The idea of tagged hashes is to prevent collisions between hashes meant for different purposes. This type allows tagging these hashes using Rust's type system so that they are semantically different from each other and can't be confused.

It also enables seamless efficient calculation of these hashes.

The `Tag::engine()` method should return a `HashEngine` that is prefilled with data. Of course, it is supposed to have this data statically initialized instead of calculated on call.

Example usage: https://github.com/rust-bitcoin/rust-bitcoin/pull/259
