### PR TITLE
sha1: Correct fuzzing behaviour.

### DIFF
--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -43,12 +43,19 @@ impl Clone for HashEngine {
 impl EngineTrait for HashEngine {
     type MidState = [u8; 20];
 
+    #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
         BigEndian::write_u32_into(&self.h, &mut ret);
         ret
     }
 
+    #[cfg(feature = "fuzztarget")]
+    fn midstate(&self) -> [u8; 20] {
+        let mut ret = [0; 20];
+        ret.copy_from_slice(&self.buffer[..20]);
+        ret
+    }
 
     const BLOCK_SIZE: usize = 64;
 


### PR DESCRIPTION
This makes the behavior of sha1's midstate function in line with everything else, which it should be since it also `write_impl!`s

We should look into how to make our files for individual hashes more DRY using macros or something else, as inconsistencies like this seem to crop up a lot when people forget to modify one file or another and is annoying.