### PR TITLE
Repository cleanup w/ help from Clippy

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -127,7 +127,7 @@ pub fn format_hex(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
     for _ in (2 * data.len())..width {
         f.write_str("0")?;
     }
-    for ch in data.into_iter().take(prec / 2) {
+    for ch in data.iter().take(prec / 2) {
         write!(f, "{:02x}", *ch)?;
     }
     if prec < 2 * data.len() && prec % 2 == 1 {

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -54,6 +54,12 @@ pub struct HmacEngine<T: HashTrait> {
     oengine: T::Engine,
 }
 
+impl<T: HashTrait> Default for HmacEngine<T> {
+    fn default() -> Self {
+        HmacEngine::new(&[])
+    }
+}
+
 impl<T: HashTrait> HmacEngine<T> {
     /// Construct a new keyed HMAC with the given key. We only support underlying hashes
     /// whose block sizes are ≤ 128 bytes; larger hashes will result in panics.
@@ -169,10 +175,6 @@ impl<T: HashTrait> borrow::Borrow<[u8]> for Hmac<T> {
 impl<T: HashTrait> HashTrait for Hmac<T> {
     type Engine = HmacEngine<T>;
     type Inner = T::Inner;
-
-    fn engine() -> HmacEngine<T> {
-        HmacEngine::new(&[])
-    }
 
     fn from_engine(mut e: HmacEngine<T>) -> Hmac<T> {
         let ihash = T::from_engine(e.iengine);

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -23,13 +23,15 @@ use core::{borrow, fmt, ops, str};
 #[cfg(feature="serde")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
-use {Error, Hash, HashEngine};
+use HashEngine as EngineTrait;
+use Hash as HashTrait;
+use Error;
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Hmac<T: Hash>(T);
+pub struct Hmac<T: HashTrait>(T);
 
-impl<T: Hash + str::FromStr> str::FromStr for Hmac<T> {
+impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {
     type Err = <T as str::FromStr>::Err;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Hmac(str::FromStr::from_str(s)?))
@@ -38,21 +40,21 @@ impl<T: Hash + str::FromStr> str::FromStr for Hmac<T> {
 
 /// Pair of underlying hash midstates which represent the current state
 /// of an `HmacEngine`
-pub struct HmacMidState<T: Hash> {
+pub struct HmacMidState<T: HashTrait> {
     /// Midstate of the inner hash engine
-    pub inner: <T::Engine as HashEngine>::MidState,
+    pub inner: <T::Engine as EngineTrait>::MidState,
     /// Midstate of the outer hash engine
-    pub outer: <T::Engine as HashEngine>::MidState,
+    pub outer: <T::Engine as EngineTrait>::MidState,
 }
 
 /// Pair of underyling hash engines, used for the inner and outer hash of HMAC
 #[derive(Clone)]
-pub struct HmacEngine<T: Hash> {
+pub struct HmacEngine<T: HashTrait> {
     iengine: T::Engine,
     oengine: T::Engine,
 }
 
-impl<T: Hash> HmacEngine<T> {
+impl<T: HashTrait> HmacEngine<T> {
     /// Construct a new keyed HMAC with the given key. We only support underlying hashes
     /// whose block sizes are ≤ 128 bytes; larger hashes will result in panics.
     pub fn new(key: &[u8]) -> HmacEngine<T> {
@@ -61,12 +63,12 @@ impl<T: Hash> HmacEngine<T> {
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
         let mut ret = HmacEngine {
-            iengine: <T as Hash>::engine(),
-            oengine: <T as Hash>::engine(),
+            iengine: <T as HashTrait>::engine(),
+            oengine: <T as HashTrait>::engine(),
         };
 
         if key.len() > T::Engine::BLOCK_SIZE {
-            let hash = <T as Hash>::hash(key);
+            let hash = <T as HashTrait>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(&hash[..]) {
                 *b_i ^= *b_h;
             }
@@ -82,13 +84,13 @@ impl<T: Hash> HmacEngine<T> {
             }
         };
 
-        HashEngine::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
-        HashEngine::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
+        EngineTrait::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
+        EngineTrait::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
         ret
     }
 }
 
-impl<T: Hash> HashEngine for HmacEngine<T> {
+impl<T: HashTrait> EngineTrait for HmacEngine<T> {
     type MidState = HmacMidState<T>;
 
     fn midstate(&self) -> Self::MidState {
@@ -105,66 +107,66 @@ impl<T: Hash> HashEngine for HmacEngine<T> {
     }
 }
 
-impl<T: Hash> fmt::Debug for Hmac<T> {
+impl<T: HashTrait> fmt::Debug for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
     }
 }
 
-impl<T: Hash> fmt::Display for Hmac<T> {
+impl<T: HashTrait> fmt::Display for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<T: Hash> fmt::LowerHex for Hmac<T> {
+impl<T: HashTrait> fmt::LowerHex for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
-impl<T: Hash> ops::Index<usize> for Hmac<T> {
+impl<T: HashTrait> ops::Index<usize> for Hmac<T> {
     type Output = u8;
     fn index(&self, index: usize) -> &u8 {
         &self.0[index]
     }
 }
 
-impl<T: Hash> ops::Index<ops::Range<usize>> for Hmac<T> {
+impl<T: HashTrait> ops::Index<ops::Range<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::Range<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: Hash> ops::Index<ops::RangeFrom<usize>> for Hmac<T> {
+impl<T: HashTrait> ops::Index<ops::RangeFrom<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: Hash> ops::Index<ops::RangeTo<usize>> for Hmac<T> {
+impl<T: HashTrait> ops::Index<ops::RangeTo<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeTo<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: Hash> ops::Index<ops::RangeFull> for Hmac<T> {
+impl<T: HashTrait> ops::Index<ops::RangeFull> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFull) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: Hash> borrow::Borrow<[u8]> for Hmac<T> {
+impl<T: HashTrait> borrow::Borrow<[u8]> for Hmac<T> {
     fn borrow(&self) -> &[u8] {
         &self[..]
     }
 }
 
-impl<T: Hash> Hash for Hmac<T> {
+impl<T: HashTrait> HashTrait for Hmac<T> {
     type Engine = HmacEngine<T>;
     type Inner = T::Inner;
 
@@ -195,14 +197,14 @@ impl<T: Hash> Hash for Hmac<T> {
 }
 
 #[cfg(feature="serde")]
-impl<T: Hash + Serialize> Serialize for Hmac<T> {
+impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(&self.0, s)
     }
 }
 
 #[cfg(feature="serde")]
-impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
+impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Hmac<T>, D::Error> {
         let inner = Deserialize::deserialize(d)?;
         Ok(Hmac(inner))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use error::Error;
 /// A hashing engine which bytes can be serialized into. It is expected
 /// to implement the `io::Write` trait, but to never return errors under
 /// any conditions.
-pub trait HashEngine: Clone {
+pub trait HashEngine: Clone + Default {
     /// Byte array representing the internal state of the hash engine
     type MidState;
 
@@ -93,7 +93,9 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     type Inner: hex::FromHex;
 
     /// Construct a new engine
-    fn engine() -> Self::Engine;
+    fn engine() -> Self::Engine {
+        Self::Engine::default()
+    }
 
     /// Produce a hash from the current state of a given engine
     fn from_engine(e: Self::Engine) -> Self;

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -29,20 +29,11 @@ use Error;
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute RIPEMD160 hash function
+#[derive(Clone)]
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
     length: usize,
-}
-
-impl Clone for HashEngine {
-    fn clone(&self) -> HashEngine {
-        HashEngine {
-            h: self.h,
-            length: self.length,
-            buffer: self.buffer,
-        }
-    }
 }
 
 impl EngineTrait for HashEngine {

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -36,6 +36,16 @@ pub struct HashEngine {
     length: usize,
 }
 
+impl Default for HashEngine {
+    fn default() -> Self {
+        HashEngine {
+            h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
+            length: 0,
+            buffer: [0; BLOCK_SIZE],
+        }
+    }
+}
+
 impl EngineTrait for HashEngine {
     type MidState = [u8; 20];
 
@@ -79,14 +89,6 @@ impl str::FromStr for Hash {
 impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
-
-    fn engine() -> HashEngine {
-        HashEngine {
-            h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
-            length: 0,
-            buffer: [0; BLOCK_SIZE],
-        }
-    }
 
     #[cfg(not(feature = "fuzztarget"))]
     fn from_engine(mut e: HashEngine) -> Hash {

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -172,8 +172,8 @@ macro_rules! process_block(
      $( par_round5: h_ordering $pf0:expr, $pf1:expr, $pf2:expr, $pf3:expr, $pf4:expr;
                     data_index $pdata_index5:expr; roll_shift $pbits5:expr; )*
     ) => ({
-        let mut bb = *$h;
-        let mut bbb = *$h;
+        let mut bb = $h;
+        let mut bbb = $h;
 
         // Round 1
         $( round!(bb[$f0], bb[$f1], bb[$f2], bb[$f3], bb[$f4],
@@ -246,7 +246,7 @@ impl HashEngine {
 
         let mut w = [0u32; 16];
         LittleEndian::read_u32_into(&self.buffer, &mut w);
-        process_block!(&mut self.h, &mut w,
+        process_block!(self.h, w,
             // Round 1
             round1: h_ordering 0, 1, 2, 3, 4; data_index  0; roll_shift 11;
             round1: h_ordering 4, 0, 1, 2, 3; data_index  1; roll_shift 14;

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -24,20 +24,11 @@ use Error;
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA1 hash function
+#[derive(Clone)]
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 5],
     length: usize,
-}
-
-impl Clone for HashEngine {
-    fn clone(&self) -> HashEngine {
-        HashEngine {
-            h: self.h,
-            length: self.length,
-            buffer: self.buffer,
-        }
-    }
 }
 
 impl EngineTrait for HashEngine {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -31,6 +31,16 @@ pub struct HashEngine {
     length: usize,
 }
 
+impl Default for HashEngine {
+    fn default() -> Self {
+        HashEngine {
+            h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
+            length: 0,
+            buffer: [0; BLOCK_SIZE],
+        }
+    }
+}
+
 impl EngineTrait for HashEngine {
     type MidState = [u8; 20];
 
@@ -74,14 +84,6 @@ impl str::FromStr for Hash {
 impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
-
-    fn engine() -> HashEngine {
-        HashEngine {
-            h: [0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0],
-            length: 0,
-            buffer: [0; BLOCK_SIZE],
-        }
-    }
 
     fn from_engine(mut e: HashEngine) -> Hash {
         // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -25,20 +25,11 @@ use Error;
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA256 hash function
+#[derive(Clone)]
 pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
     h: [u32; 8],
     length: usize,
-}
-
-impl Clone for HashEngine {
-    fn clone(&self) -> HashEngine {
-        HashEngine {
-            h: self.h,
-            length: self.length,
-            buffer: self.buffer,
-        }
-    }
 }
 
 impl EngineTrait for HashEngine {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -32,6 +32,16 @@ pub struct HashEngine {
     length: usize,
 }
 
+impl Default for HashEngine {
+    fn default() -> Self {
+        HashEngine {
+            h: [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19],
+            length: 0,
+            buffer: [0; BLOCK_SIZE],
+        }
+    }
+}
+
 impl EngineTrait for HashEngine {
     type MidState = Midstate;
 
@@ -75,14 +85,6 @@ borrow_slice_impl!(Hash);
 impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 32];
-
-    fn engine() -> HashEngine {
-        HashEngine {
-            h: [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19],
-            length: 0,
-            buffer: [0; BLOCK_SIZE],
-        }
-    }
 
     #[cfg(not(feature = "fuzztarget"))]
     fn from_engine(mut e: HashEngine) -> Hash {

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -37,6 +37,19 @@ pub struct HashEngine {
     buffer: [u8; BLOCK_SIZE],
 }
 
+impl Default for HashEngine {
+    fn default() -> Self {
+        HashEngine {
+            h: [
+                0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
+                0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179,
+            ],
+            length: 0,
+            buffer: [0; BLOCK_SIZE],
+        }
+    }
+}
+
 impl EngineTrait for HashEngine {
     type MidState = [u8; 64];
 
@@ -121,17 +134,6 @@ borrow_slice_impl!(Hash);
 impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 64];
-
-    fn engine() -> HashEngine {
-        HashEngine {
-            h: [
-                0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
-                0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179,
-            ],
-            length: 0,
-            buffer: [0; BLOCK_SIZE],
-        }
-    }
 
     #[cfg(not(feature = "fuzztarget"))]
     fn from_engine(mut e: HashEngine) -> Hash {

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -30,20 +30,11 @@ use Error;
 const BLOCK_SIZE: usize = 128;
 
 /// Engine to compute SHA512 hash function
+#[derive(Clone)]
 pub struct HashEngine {
     h: [u64; 8],
     length: usize,
     buffer: [u8; BLOCK_SIZE],
-}
-
-impl Clone for HashEngine {
-    fn clone(&self) -> HashEngine {
-        HashEngine {
-            h: self.h,
-            length: self.length,
-            buffer: self.buffer,
-        }
-    }
 }
 
 impl EngineTrait for HashEngine {

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -298,15 +298,15 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
     let mut i = 0; // current byte index (from LSB) in the output u64
     let mut out = 0;
     if i + 3 < len {
-        out = load_int_le!(buf, start + i, u32) as u64;
+        out = u64::from(load_int_le!(buf, start + i, u32));
         i += 4;
     }
     if i + 1 < len {
-        out |= (load_int_le!(buf, start + i, u16) as u64) << (i * 8);
+        out |= u64::from(load_int_le!(buf, start + i, u16)) << (i * 8);
         i += 2
     }
     if i < len {
-        out |= (*buf.get_unchecked(start + i) as u64) << (i * 8);
+        out |= u64::from(*buf.get_unchecked(start + i)) << (i * 8);
         i += 1;
     }
     debug_assert_eq!(i, len);

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -134,6 +134,12 @@ impl HashEngine {
     }
 }
 
+impl Default for HashEngine {
+    fn default() -> Self {
+        HashEngine::new()
+    }
+}
+
 impl EngineTrait for HashEngine {
     type MidState = State;
 
@@ -250,10 +256,6 @@ impl Hash {
 impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 8];
-
-    fn engine() -> HashEngine {
-        HashEngine::new()
-    }
 
     #[cfg(not(feature = "fuzztarget"))]
     fn from_engine(e: HashEngine) -> Hash {


### PR DESCRIPTION
Various cleanups inspired by clippy output. Added sane clippy allows in the last commit. `cargo clippy` should have empty output after this is merged.