### PR TITLE
Make sha256::Midstate's inner variable public

### DIFF
--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -136,7 +136,7 @@ impl HashTrait for Hash {
 
 /// Output of the SHA256 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Midstate([u8; 32]);
+pub struct Midstate(pub [u8; 32]);
 
 hex_fmt_impl!(Debug, Midstate);
 hex_fmt_impl!(Display, Midstate);


### PR DESCRIPTION
This allows creating const midstates.

Seperate PR from https://github.com/rust-bitcoin/bitcoin_hashes/pull/61 because this change is doesn't need a major version bump and is this compatible with https://github.com/rust-bitcoin/bitcoin_hashes/pull/42.