### PR TITLE
Fixing `hash_newtype` macro to work correctly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,18 @@ macro_rules! hash_newtype {
             }
         }
 
+        impl ::std::convert::From<$hash> for $newtype {
+            fn from(inner: $hash) -> Self {
+                Self::from_inner($hash)
+            }
+        }
+
+        impl ::std::convert::To<$hash> for $newtype {
+            fn to(&self) -> $hash {
+                Self::to_inner()
+            }
+        }
+
         impl $newtype {
             /// The length in bytes.
             pub const LEN: usize = <$hash as $crate::Hash>::LEN;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
-#[cfg(any(test, feature="std"))] extern crate core;
-#[cfg(feature="serde")] extern crate serde;
-#[cfg(all(test,feature="serde"))] extern crate serde_test;
+#[cfg(any(test, feature="std"))] pub extern crate core;
+#[cfg(feature="serde")] pub extern crate serde;
+#[cfg(all(test, feature="serde"))] extern crate serde_test;
 extern crate byteorder;
 
 #[macro_use] mod util;
@@ -140,18 +140,18 @@ macro_rules! hash_newtype {
         serde_impl!($newtype, $len);
         borrow_slice_impl!($newtype);
 
-        impl ::hex::FromHex for $newtype {
-            fn from_byte_iter<I>(iter: I) -> Result<Self, ::hex::Error>
-                where I: Iterator<Item=Result<u8, ::hex::Error>> +
+        impl $crate::hex::FromHex for $newtype {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hex::Error>
+                where I: Iterator<Item=Result<u8, $crate::hex::Error>> +
                     ExactSizeIterator +
                     DoubleEndedIterator,
             {
-                Ok($newtype(::hex::FromHex::from_byte_iter(iter)?))
+                Ok($newtype($crate::hex::FromHex::from_byte_iter(iter)?))
             }
         }
 
         impl ::std::str::FromStr for $newtype {
-            type Err = ::hex::Error;
+            type Err = $crate::hex::Error;
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 ::hex::FromHex::from_hex(s)
             }
@@ -159,10 +159,10 @@ macro_rules! hash_newtype {
 
         impl $newtype {
             /// The length in bytes.
-            pub const LEN: usize = <$hash as ::Hash>::LEN;
+            pub const LEN: usize = <$hash as $crate::Hash>::LEN;
 
             /// Whether this type should be displayed backwards.
-            pub const DISPLAY_BACKWARD: bool = <$hash as ::Hash>::DISPLAY_BACKWARD;
+            pub const DISPLAY_BACKWARD: bool = <$hash as $crate::Hash>::DISPLAY_BACKWARD;
 
             /// Construct from the inner value.
             pub fn from_inner(inner: $hash) -> Self {
@@ -170,8 +170,8 @@ macro_rules! hash_newtype {
             }
 
             /// Construct from a byte slice.
-            pub fn from_slice(sl: &[u8]) -> Result<$newtype, ::error::Error> {
-                Ok($newtype(<$hash as ::Hash>::from_slice(sl)?))
+            pub fn from_slice(sl: &[u8]) -> Result<$newtype, $crate::Error> {
+                Ok($newtype(<$hash as $crate::Hash>::from_slice(sl)?))
             }
 
             /// Unwraps and returns the underlying value.

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -1,11 +1,12 @@
 
+#[macro_export]
 #[cfg(feature="serde")]
 /// Implements `Serialize` and `Deserialize` for a type `$t` which
 /// represents a newtype over a byte-slice over length `$len`.
 macro_rules! serde_impl(
     ($t:ident, $len:expr) => (
-        impl ::serde::Serialize for $t {
-            fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        impl $crate::serde::Serialize for $t {
+            fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 use hex::ToHex;
                 if s.is_human_readable() {
                     s.serialize_str(&self.to_hex())
@@ -15,14 +16,14 @@ macro_rules! serde_impl(
             }
         }
 
-        impl<'de> ::serde::Deserialize<'de> for $t {
-            fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
+        impl<'de> $crate::serde::Deserialize<'de> for $t {
+            fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
                 use hex::FromHex;
 
                 if d.is_human_readable() {
                     struct HexVisitor;
 
-                    impl<'de> ::serde::de::Visitor<'de> for HexVisitor {
+                    impl<'de> $crate::serde::de::Visitor<'de> for HexVisitor {
                         type Value = $t;
 
                         fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -31,18 +32,18 @@ macro_rules! serde_impl(
 
                         fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
                         where
-                            E: ::serde::de::Error,
+                            E: $crate::serde::de::Error,
                         {
                             if let Ok(hex) = ::std::str::from_utf8(v) {
                                 $t::from_hex(hex).map_err(E::custom)
                             } else {
-                                return Err(E::invalid_value(::serde::de::Unexpected::Bytes(v), &self));
+                                return Err(E::invalid_value($crate::serde::de::Unexpected::Bytes(v), &self));
                             }
                         }
 
                         fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
                         where
-                            E: ::serde::de::Error,
+                            E: $crate::serde::de::Error,
                         {
                             $t::from_hex(v).map_err(E::custom)
                         }
@@ -52,7 +53,7 @@ macro_rules! serde_impl(
                 } else {
                     struct BytesVisitor;
 
-                    impl<'de> ::serde::de::Visitor<'de> for BytesVisitor {
+                    impl<'de> $crate::serde::de::Visitor<'de> for BytesVisitor {
                         type Value = $t;
 
                         fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
@@ -61,7 +62,7 @@ macro_rules! serde_impl(
 
                         fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
                         where
-                            E: ::serde::de::Error,
+                            E: $crate::serde::de::Error,
                         {
                             $t::from_slice(v).map_err(|_| {
                                 // from_slice only errors on incorrect length
@@ -77,7 +78,9 @@ macro_rules! serde_impl(
     )
 );
 
+#[macro_export]
 #[cfg(not(feature="serde"))]
+#[macro_export]
 macro_rules! serde_impl(
     ($t:ident, $len:expr) => ()
 );

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,11 +21,12 @@ macro_rules! circular_lshift64 (
     ($shift:expr, $w:expr) => (($w << $shift) | ($w >> (64 - $shift)))
 );
 
+#[macro_export]
 macro_rules! hex_fmt_impl(
     ($imp:ident, $ty:ident) => (
-        impl ::core::fmt::$imp for $ty {
-            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                use hex::{format_hex, format_hex_reverse};
+        impl $crate::core::fmt::$imp for $ty {
+            fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
+                use $crate::hex::{format_hex, format_hex_reverse};
                 if $ty::DISPLAY_BACKWARD {
                     format_hex_reverse(&self.0, f)
                 } else {
@@ -36,60 +37,62 @@ macro_rules! hex_fmt_impl(
     )
 );
 
+#[macro_export]
 macro_rules! index_impl(
     ($ty:ty) => (
-        impl ::core::ops::Index<usize> for $ty {
+        impl $crate::core::ops::Index<usize> for $ty {
             type Output = u8;
             fn index(&self, index: usize) -> &u8 {
                 &self.0[index]
             }
         }
 
-        impl ::core::ops::Index<::core::ops::Range<usize>> for $ty {
+        impl $crate::core::ops::Index<$crate::core::ops::Range<usize>> for $ty {
             type Output = [u8];
-            fn index(&self, index: ::core::ops::Range<usize>) -> &[u8] {
+            fn index(&self, index: $crate::core::ops::Range<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $ty {
+        impl $crate::core::ops::Index<$crate::core::ops::RangeFrom<usize>> for $ty {
             type Output = [u8];
-            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[u8] {
+            fn index(&self, index: $crate::core::ops::RangeFrom<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $ty {
+        impl $crate::core::ops::Index<$crate::core::ops::RangeTo<usize>> for $ty {
             type Output = [u8];
-            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[u8] {
+            fn index(&self, index: $crate::core::ops::RangeTo<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl ::core::ops::Index<::core::ops::RangeFull> for $ty {
+        impl $crate::core::ops::Index<$crate::core::ops::RangeFull> for $ty {
             type Output = [u8];
-            fn index(&self, index: ::core::ops::RangeFull) -> &[u8] {
+            fn index(&self, index: $crate::core::ops::RangeFull) -> &[u8] {
                 &self.0[index]
             }
         }
     )
 );
 
+#[macro_export]
 macro_rules! borrow_slice_impl(
     ($ty:ty) => (
-        impl ::core::borrow::Borrow<[u8]> for $ty {
+        impl $crate::core::borrow::Borrow<[u8]> for $ty {
             fn borrow(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl ::core::convert::AsRef<[u8]> for $ty {
+        impl $crate::core::convert::AsRef<[u8]> for $ty {
             fn as_ref(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl ::core::ops::Deref for $ty {
+        impl $crate::core::ops::Deref for $ty {
             type Target = [u8];
 
             fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
While I was working on implementing https://github.com/rust-bitcoin/rust-bitcoin/issues/284 I've found that the new `hash_newtype` can't be used outside of `bitcoin_hashes` project due to fact that macros used by it are not exported. This PR fixes the problem for most of such macros.

~~Nevertheless, I am still not able to run https://github.com/pandoracore/rust-bitcoin/blob/hashtypes/src/lib.rs#L67 due to problems with `serde` crate access from inside `hash_newtype` macro. Any suggestions?~~