### PR TITLE
Drop byteorder dependency (and disable some useless, particularly obnoxious, lints)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/lib.rs"
 
 [features]
 default = [ "std" ]
-std = ["byteorder/std", "serde/std"]
+std = []
+serde-std = ["serde/std"]
 unstable = []  # for benchmarking
 fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noops, DON'T USE THIS
 
@@ -22,7 +23,6 @@ fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noop
 serde_test = "1.0"
 
 [dependencies]
-byteorder = { version = "1.2", default-features = false }
 
 [dependencies.serde]
 version = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@
 #[cfg(any(test, feature="std"))] extern crate core;
 #[cfg(feature="serde")] extern crate serde;
 #[cfg(all(test,feature="serde"))] extern crate serde_test;
-extern crate byteorder;
 
 #[macro_use] mod util;
 #[macro_use] mod serde_macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,12 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
+// In general, rust is absolutely horrid at supporting users doing things like,
+// for example, compiling Rust code for real environments. Disable useless lints
+// that don't do anything but annoy us and cant actually ever be resolved.
+#![allow(bare_trait_objects)]
+#![allow(ellipsis_inclusive_range_patterns)]
+
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -14,12 +14,12 @@
 
 //! # SHA1
 
-use byteorder::{ByteOrder, BigEndian};
 use core::{cmp, str};
 
 use HashEngine as EngineTrait;
 use Hash as HashTrait;
 use Error;
+use util;
 
 const BLOCK_SIZE: usize = 64;
 
@@ -47,7 +47,9 @@ impl EngineTrait for HashEngine {
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
-        BigEndian::write_u32_into(&self.h, &mut ret);
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
+            ret_bytes.copy_from_slice(&util::u32_to_array_be(*val));
+        }
         ret
     }
 
@@ -98,9 +100,7 @@ impl HashTrait for Hash {
         e.input(&zeroes[..pad_length]);
         debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
         
-        let mut len_buf = [0; 8];
-        BigEndian::write_u64(&mut len_buf, 8 * data_len);
-        e.input(&len_buf);
+        e.input(&util::u64_to_array_be(8 * data_len));
         debug_assert_eq!(e.length % BLOCK_SIZE, 0);
 
         Hash(e.midstate())
@@ -133,7 +133,9 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u32; 80];
-        BigEndian::read_u32_into(&self.buffer, &mut w[0..16]);
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(4)) {
+            *w_val = util::slice_to_u32_be(buff_bytes);
+        }
         for i in 16..80 {
             w[i] = circular_lshift32!(1, w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
         }

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -14,13 +14,13 @@
 
 //! # SHA256
 
-use byteorder::{ByteOrder, BigEndian};
 use core::{cmp, str};
 
 use hex;
 use HashEngine as EngineTrait;
 use Hash as HashTrait;
 use Error;
+use util;
 
 const BLOCK_SIZE: usize = 64;
 
@@ -48,7 +48,9 @@ impl EngineTrait for HashEngine {
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> Midstate {
         let mut ret = [0; 32];
-        BigEndian::write_u32_into(&self.h, &mut ret);
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
+            ret_bytes.copy_from_slice(&util::u32_to_array_be(*val));
+        }
         Midstate(ret)
     }
 
@@ -100,9 +102,7 @@ impl HashTrait for Hash {
         e.input(&zeroes[..pad_length]);
         debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
 
-        let mut len_buf = [0; 8];
-        BigEndian::write_u64(&mut len_buf, 8 * data_len);
-        e.input(&len_buf);
+        e.input(&util::u64_to_array_be(8 * data_len));
         debug_assert_eq!(e.length % BLOCK_SIZE, 0);
 
         Hash(e.midstate().into_inner())
@@ -224,7 +224,9 @@ impl HashEngine {
         assert!(length % BLOCK_SIZE == 0, "length is no multiple of the block size");
 
         let mut ret = [0; 8];
-        BigEndian::read_u32_into(&midstate[..], &mut ret);
+        for (ret_val, midstate_bytes) in ret.iter_mut().zip(midstate[..].chunks(4)) {
+            *ret_val = util::slice_to_u32_be(midstate_bytes);
+        }
 
         HashEngine {
             buffer: [0; BLOCK_SIZE],
@@ -238,7 +240,9 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u32; 16];
-        BigEndian::read_u32_into(&self.buffer, &mut w);
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(4)) {
+            *w_val = util::slice_to_u32_be(buff_bytes);
+        }
 
         let mut a = self.h[0];
         let mut b = self.h[1];

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -21,11 +21,10 @@
 
 use core::{cmp, hash, str};
 
-use byteorder::{ByteOrder, BigEndian};
-
 use HashEngine as EngineTrait;
 use Hash as HashTrait;
 use Error;
+use util;
 
 const BLOCK_SIZE: usize = 128;
 
@@ -56,7 +55,9 @@ impl EngineTrait for HashEngine {
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> [u8; 64] {
         let mut ret = [0; 64];
-        BigEndian::write_u64_into(&self.h, &mut ret);
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(8)) {
+            ret_bytes.copy_from_slice(&util::u64_to_array_be(*val));
+        }
         ret
     }
 
@@ -149,10 +150,8 @@ impl HashTrait for Hash {
         e.input(&zeroes[..pad_length]);
         debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
 
-        let mut len_buf = [0; 8];
-        e.input(&len_buf);
-        BigEndian::write_u64(&mut len_buf, 8 * data_len);
-        e.input(&len_buf);
+        e.input(&[0; 8]);
+        e.input(&util::u64_to_array_be(8 * data_len));
         debug_assert_eq!(e.length % BLOCK_SIZE, 0);
 
         Hash(e.midstate())
@@ -214,7 +213,9 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u64; 16];
-        BigEndian::read_u64_into(&self.buffer, &mut w);
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(8)) {
+            *w_val = util::slice_to_u64_be(buff_bytes);
+        }
 
         let mut a = self.h[0];
         let mut b = self.h[1];

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -21,11 +21,10 @@
 
 use core::{cmp, mem, ptr, str};
 
-use byteorder::{ByteOrder, LittleEndian};
-
 use Error;
 use Hash as HashTrait;
 use HashEngine as EngineTrait;
+use util;
 
 macro_rules! compress {
     ($state:expr) => {{
@@ -242,14 +241,12 @@ impl Hash {
 
     /// Returns the (little endian) 64-bit integer representation of the hash value.
     pub fn as_u64(&self) -> u64 {
-        LittleEndian::read_u64(&self.0)
+        util::slice_to_u64_le(&self.0[..])
     }
 
     /// Create a hash from its (little endian) 64-bit integer representation.
     pub fn from_u64(hash: u64) -> Hash {
-        let mut ret = [0; 8];
-        LittleEndian::write_u64(&mut ret, hash);
-        Hash(ret)
+        Hash(util::u64_to_array_le(hash))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -128,15 +128,94 @@ macro_rules! engine_input_impl(
     )
 );
 
+
+
+macro_rules! define_slice_to_be {
+    ($name: ident, $type: ty) => {
+        #[inline]
+        pub fn $name(slice: &[u8]) -> $type {
+            assert_eq!(slice.len(), ::core::mem::size_of::<$type>());
+            let mut res = 0;
+            for i in 0..::core::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << (::core::mem::size_of::<$type>() - i - 1)*8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_slice_to_le {
+    ($name: ident, $type: ty) => {
+        #[inline]
+        pub fn $name(slice: &[u8]) -> $type {
+            assert_eq!(slice.len(), ::core::mem::size_of::<$type>());
+            let mut res = 0;
+            for i in 0..::core::mem::size_of::<$type>() {
+                res |= (slice[i] as $type) << i*8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_be_to_array {
+    ($name: ident, $type: ty, $byte_len: expr) => {
+        #[inline]
+        pub fn $name(val: $type) -> [u8; $byte_len] {
+            assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            let mut res = [0; $byte_len];
+            for i in 0..$byte_len {
+                res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
+            }
+            res
+        }
+    }
+}
+macro_rules! define_le_to_array {
+    ($name: ident, $type: ty, $byte_len: expr) => {
+        #[inline]
+        pub fn $name(val: $type) -> [u8; $byte_len] {
+            assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
+            let mut res = [0; $byte_len];
+            for i in 0..$byte_len {
+                res[i] = ((val >> i*8) & 0xff) as u8;
+            }
+            res
+        }
+    }
+}
+
+define_slice_to_be!(slice_to_u32_be, u32);
+define_slice_to_be!(slice_to_u64_be, u64);
+define_be_to_array!(u32_to_array_be, u32, 4);
+define_be_to_array!(u64_to_array_be, u64, 8);
+
+define_slice_to_le!(slice_to_u32_le, u32);
+define_slice_to_le!(slice_to_u64_le, u64);
+define_le_to_array!(u32_to_array_le, u32, 4);
+define_le_to_array!(u64_to_array_le, u64, 8);
+
 #[cfg(test)]
 mod test {
     use Hash;
     use sha256;
+    use super::*;
 
     #[test]
     fn borrow_slice_impl_to_vec() {
         // Test that the borrow_slice_impl macro gives to_vec.
         let hash = sha256::Hash::hash(&[3, 50]);
         assert_eq!(hash.to_vec().len(), sha256::Hash::LEN);
+    }
+
+    #[test]
+    fn endianness_test() {
+        assert_eq!(slice_to_u32_be(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
+        assert_eq!(slice_to_u64_be(&[0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef]), 0x1badcafedeadbeef);
+        assert_eq!(u32_to_array_be(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(u64_to_array_be(0x1badcafedeadbeef), [0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef]);
+
+        assert_eq!(slice_to_u32_le(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);
+        assert_eq!(slice_to_u64_le(&[0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]), 0x1badcafedeadbeef);
+        assert_eq!(u32_to_array_le(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
+        assert_eq!(u64_to_array_le(0x1badcafedeadbeef), [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]);
     }
 }


### PR DESCRIPTION
Taking an external dependency just to convert ints to byte arrays
is somewhat of a waste, especially when Rust isn't very aggressive
about doing cross-crate LTO.

Note that the latest LLVM pattern-matches this, and while I haven't tested it, that should mean this means no loss of optimization.