### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,39 @@
 language: rust
+cache: 
+  cargo: true
+  directories:
+  - cargo_web
+
 rust:
   - stable
   - beta
   - nightly
   - 1.22.0
 
+jobs:
+  include:
+    - rust: stable
+      env: FUZZ=true
+    - rust: stable
+      env: WASM=true
+
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y binutils-dev libunwind8-dev
 
 script:
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo test --verbose --features "serde"
-  - cargo build --verbose --features "fuzztarget"
-  - cargo build --verbose --no-default-features
-  - if [ "$(rustup show | grep default | grep beta)" != "" ]; then cargo install --force cargo-web && cargo web build --target=asmjs-unknown-emscripten && cargo web test --target=asmjs-unknown-emscripten --nodejs; fi
-  - if [ "$(rustup show | grep default | grep stable)" != "" ]; then cd fuzz && cargo test --verbose && ./travis-fuzz.sh; fi
+  - |
+      if [ "$FUZZ" = "true" ]; then
+        cd fuzz && cargo test --verbose && ./travis-fuzz.sh;
+      elif [ "$WASM" = "true" ]; then
+        CARGO_TARGET_DIR=cargo_web cargo install --force cargo-web
+        cargo web build --target=asmjs-unknown-emscripten
+        cargo web test --target=asmjs-unknown-emscripten --nodejs
+      else
+        cargo build --verbose
+        cargo test --verbose
+        cargo test --verbose --features "serde"
+        cargo build --verbose --features "fuzztarget"
+        cargo build --verbose --no-default-features
+      fi


### PR DESCRIPTION
Travis lately is failing with `cargo web`,
it seems to be related to a bump in llvm in beta which apparently was fixed here: https://github.com/rust-lang/rust/commit/2bf59bea481dd4b4365cafe2e94fa8bf330a6877

IIUC the reason it ran on beta is so it won't clog up the stable run (because it already has fuzzing there)
https://github.com/rust-bitcoin/bitcoin_hashes/compare/aa468e7de40379fd6e9a909ec8fc6b004ca0aac1..785b57b1f8e7a6b90089e682cc85850b1f1f99f7

So I splitted the jobs here to have the regular stable+beta+nightly+MSRV jobs, and on top of those stable+wasm and stable+fuzzing.
I also enabled caching like I did here: https://github.com/rust-bitcoin/rust-secp256k1/pull/148 so that the install of `cargo-web` won't take 10 minutes.

@TheBlueMatt