### PR TITLE
Adding back crate exports required by hash_newtype macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,8 @@ macro_rules! hash_newtype {
 
         impl ::std::convert::From<$hash> for $newtype {
             fn from(inner: $hash) -> $newtype {
-                Self(inner)
+                // Due to rust 1.22 we have to use this instead of simple `Self(inner)`
+                Self { 0: inner }
             }
         }
 
@@ -165,7 +166,7 @@ macro_rules! hash_newtype {
             const DISPLAY_BACKWARD: bool = <$hash as $crate::Hash>::DISPLAY_BACKWARD;
 
             fn from_engine(e: Self::Engine) -> Self {
-                Self(<$hash as $crate::Hash>::from_engine(e))
+                Self::from(<$hash as $crate::Hash>::from_engine(e))
             }
 
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
-#[cfg(any(test, feature="std"))] extern crate core;
-#[cfg(feature="serde")] extern crate serde;
+#[cfg(any(test, feature="std"))] pub extern crate core;
+#[cfg(feature="serde")] pub extern crate serde;
 #[cfg(all(test,feature="serde"))] extern crate serde_test;
 
 #[macro_use] mod util;


### PR DESCRIPTION
They were missed due to the last auto merge from the master