### PR TITLE
Make hex path in serde macros relative to the crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 description = "Hash functions used by rust-bitcoin which support rustc 1.14.0"

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -7,7 +7,7 @@ macro_rules! serde_impl(
     ($t:ident, $len:expr) => (
         impl $crate::serde::Serialize for $t {
             fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-                use hex::ToHex;
+                use $crate::hex::ToHex;
                 if s.is_human_readable() {
                     s.serialize_str(&self.to_hex())
                 } else {
@@ -18,7 +18,7 @@ macro_rules! serde_impl(
 
         impl<'de> $crate::serde::Deserialize<'de> for $t {
             fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
-                use hex::FromHex;
+                use $crate::hex::FromHex;
 
                 if d.is_human_readable() {
                     struct HexVisitor;


### PR DESCRIPTION
Currently the serde macros (use in creating new hash types) did:
`use hex::ToHex;`
which works fine in this library but not anywhere else.
the only reason it works in `rust-bitcoin` is because it actually used the `hex` crate(https://docs.rs/hex/0.4.0/hex/trait.ToHex.html) without anyone noticing (which was left in non-test code by accident) 

so now it should use the correct hex traits.