### PR TITLE
Cleaning up macro namespaces

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -201,9 +201,9 @@ macro_rules! impl_fromhex_array {
     ($len:expr) => {
         impl $crate::hex::FromHex for [u8; $len] {
             fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hex::Error>
-                where I: ::std::iter::Iterator<Item=Result<u8, $crate::hex::Error>> +
-                    ::std::iter::ExactSizeIterator +
-                    ::std::iter::DoubleEndedIterator,
+                where I: ::core::iter::Iterator<Item=Result<u8, $crate::hex::Error>> +
+                    ::core::iter::ExactSizeIterator +
+                    ::core::iter::DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -199,11 +199,11 @@ impl FromHex for Vec<u8> {
 
 macro_rules! impl_fromhex_array {
     ($len:expr) => {
-        impl FromHex for [u8; $len] {
-            fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-                where I: Iterator<Item=Result<u8, Error>> +
-                    ExactSizeIterator +
-                    DoubleEndedIterator,
+        impl $crate::hex::FromHex for [u8; $len] {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hex::Error>
+                where I: ::std::iter::Iterator<Item=Result<u8, $crate::hex::Error>> +
+                    ::std::iter::ExactSizeIterator +
+                    ::std::iter::DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];
@@ -212,7 +212,7 @@ macro_rules! impl_fromhex_array {
                     }
                     Ok(ret)
                 } else {
-                    Err(Error::InvalidLength(2 * $len, 2 * iter.len()))
+                    Err($crate::hex::Error::InvalidLength(2 * $len, 2 * iter.len()))
                 }
             }
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,8 +26,8 @@ macro_rules! circular_lshift64 (
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`
 macro_rules! hex_fmt_impl(
     ($imp:ident, $ty:ident) => (
-        impl $crate::core::fmt::$imp for $ty {
-            fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
+        impl ::core::fmt::$imp for $ty {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 use $crate::hex::{format_hex, format_hex_reverse};
                 if $ty::DISPLAY_BACKWARD {
                     format_hex_reverse(&self.0, f)
@@ -43,37 +43,37 @@ macro_rules! hex_fmt_impl(
 #[macro_export]
 macro_rules! index_impl(
     ($ty:ty) => (
-        impl $crate::core::ops::Index<usize> for $ty {
+        impl ::core::ops::Index<usize> for $ty {
             type Output = u8;
             fn index(&self, index: usize) -> &u8 {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::Range<usize>> for $ty {
+        impl ::core::ops::Index<::core::ops::Range<usize>> for $ty {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::Range<usize>) -> &[u8] {
+            fn index(&self, index: ::core::ops::Range<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::RangeFrom<usize>> for $ty {
+        impl ::core::ops::Index<::core::ops::RangeFrom<usize>> for $ty {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::RangeFrom<usize>) -> &[u8] {
+            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::RangeTo<usize>> for $ty {
+        impl ::core::ops::Index<::core::ops::RangeTo<usize>> for $ty {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::RangeTo<usize>) -> &[u8] {
+            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl $crate::core::ops::Index<$crate::core::ops::RangeFull> for $ty {
+        impl ::core::ops::Index<::core::ops::RangeFull> for $ty {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::RangeFull) -> &[u8] {
+            fn index(&self, index: ::core::ops::RangeFull) -> &[u8] {
                 &self.0[index]
             }
         }
@@ -84,19 +84,19 @@ macro_rules! index_impl(
 #[macro_export]
 macro_rules! borrow_slice_impl(
     ($ty:ty) => (
-        impl $crate::core::borrow::Borrow<[u8]> for $ty {
+        impl ::core::borrow::Borrow<[u8]> for $ty {
             fn borrow(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl $crate::core::convert::AsRef<[u8]> for $ty {
+        impl ::core::convert::AsRef<[u8]> for $ty {
             fn as_ref(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl $crate::core::ops::Deref for $ty {
+        impl ::core::ops::Deref for $ty {
             type Target = [u8];
 
             fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
I tried to apply the same rules to all macros:
* for identities from outside of the crate, belonging to `std` and `core` use `::std::...` and `::core::..`
* for all other, use `$crate::`

Rationale: I had run an issue when compiler says `no core` while importing some macro and using it in the mods that do not import core directly.

Related / additional info: https://github.com/rust-bitcoin/rust-bitcoin/pull/395