### PR TITLE
Support hash_newtypes with reversed serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 0.7.6 - 2020-04-05
+
+* Support hash newtypes with reversed hex serialization.
+
 # 0.7.5 - 2020-04-02
 
 * Add `sha256t` module for SHA-256-based tagged hashes.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 description = "Hash functions used by rust-bitcoin which support rustc 1.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,9 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
 #[macro_export]
 macro_rules! hash_newtype {
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta) => {
+        hash_newtype!($newtype, $hash, $len, $docs, <$hash as $crate::Hash>::DISPLAY_BACKWARD);
+    };
+    ($newtype:ident, $hash:ty, $len:expr, $docs:meta, $reverse:expr) => {
         #[$docs]
         #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
         pub struct $newtype($hash);
@@ -177,7 +180,7 @@ macro_rules! hash_newtype {
             type Inner = <$hash as $crate::Hash>::Inner;
 
             const LEN: usize = <$hash as $crate::Hash>::LEN;
-            const DISPLAY_BACKWARD: bool = <$hash as $crate::Hash>::DISPLAY_BACKWARD;
+            const DISPLAY_BACKWARD: bool = $reverse;
 
             fn from_engine(e: Self::Engine) -> Self {
                 Self::from(<$hash as $crate::Hash>::from_engine(e))


### PR DESCRIPTION
We'd like to have a `sha256::Hash` newtype that for some reason we want to be reverse serialized to be compatible with an RPC that parses it reverse.