### PR TITLE
Add a hashed fn to EngineTrait

### DIFF
--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -107,7 +107,11 @@ impl<T: HashTrait> EngineTrait for HmacEngine<T> {
     }
 
     const BLOCK_SIZE: usize = T::Engine::BLOCK_SIZE;
-    
+
+    fn n_bytes_hashed(&self) -> usize {
+        self.iengine.n_bytes_hashed()
+    }
+
     fn input(&mut self, buf: &[u8]) {
         self.iengine.input(buf)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,9 @@ pub trait HashEngine: Clone + Default {
 
     /// Add data to the hash engine
     fn input(&mut self, data: &[u8]);
+
+    /// Return the number of bytes already n_bytes_hashed(inputted)
+    fn n_bytes_hashed(&self) -> usize;
 }
 
 /// Trait which applies to hashes of all types

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -67,6 +67,10 @@ impl EngineTrait for HashEngine {
 
     const BLOCK_SIZE: usize = 64;
 
+    fn n_bytes_hashed(&self) -> usize {
+        self.length
+    }
+
     engine_input_impl!();
 }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -62,6 +62,10 @@ impl EngineTrait for HashEngine {
 
     const BLOCK_SIZE: usize = 64;
 
+    fn n_bytes_hashed(&self) -> usize {
+        self.length
+    }
+
     engine_input_impl!();
 }
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -63,6 +63,10 @@ impl EngineTrait for HashEngine {
 
     const BLOCK_SIZE: usize = 64;
 
+    fn n_bytes_hashed(&self) -> usize {
+        self.length
+    }
+
     engine_input_impl!();
 }
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -70,6 +70,10 @@ impl EngineTrait for HashEngine {
 
     const BLOCK_SIZE: usize = 128;
 
+    fn n_bytes_hashed(&self) -> usize {
+        self.length
+    }
+
     engine_input_impl!();
 }
 

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -187,6 +187,11 @@ impl EngineTrait for HashEngine {
         self.tail = unsafe { u8to64_le(msg, i, left) };
         self.ntail = left;
     }
+
+    fn n_bytes_hashed(&self) -> usize {
+        self.length
+    }
+
 }
 
 /// Output of the SipHash24 hash function.


### PR DESCRIPTION
This is useful for places like:  https://github.com/rust-bitcoin/rust-bitcoin/pull/422
When encoding into a vec we do a sanity assert that the lengths match https://github.com/rust-bitcoin/rust-bitcoin/blob/master/src/consensus/encode.rs#L154

this will allow us to do it also when using a hasher.

I'm open to suggestions about the function name because technically not all the bytes were "hashed" yet. but I might be bikeshedding it to much.