### PR TITLE
Fix FromStr for hash newtypes with custom hex order

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,9 +203,9 @@ macro_rules! hash_newtype {
         }
 
         impl ::std::str::FromStr for $newtype {
-            type Err = <$hash as ::std::str::FromStr>::Err;
+            type Err = ::hex::Error;
             fn from_str(s: &str) -> ::std::result::Result<$newtype, Self::Err> {
-                s.parse().map($newtype)
+                ::hex::FromHex::from_hex(s)
             }
         }
     };


### PR DESCRIPTION
So FromStr doesn't seem to just refer to FromHex like it should. This fixes that. This bug only manifests for newtypes that have a different hex order than their inner type.