### PR TITLE
Make it easy to access the contents of any hash (newtype)

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -42,6 +42,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,6 +181,12 @@ macro_rules! hash_newtype {
             }
         }
 
+        impl ::std::convert::From<$newtype> for <$hash as $crate::Hash>::Inner {
+            fn from(hashtype: $newtype) -> <$hash as $crate::Hash>::Inner {
+                hashtype.0.into_inner()
+            }
+        }
+
         impl $crate::Hash for $newtype {
             type Engine = <$hash as $crate::Hash>::Engine;
             type Inner = <$hash as $crate::Hash>::Inner;
@@ -241,6 +247,17 @@ mod test {
         let h = ::sha256d::Hash::hash(&[]);
         let h2: TestNewtype = h.to_string().parse().unwrap();
         assert_eq!(h2.as_hash(), h);
+    }
+
+    #[test]
+    fn convert_using_std_into() {
+        fn i_accept_plain_arrays<T: Into<[u8; 32]>>(whatever: T) {
+            let _x = whatever.into();
+        }
+
+        let h1 = TestNewtype::hash(&[]);
+
+        i_accept_plain_arrays(h1);
     }
 }
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -88,6 +88,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -83,6 +83,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -91,6 +91,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl HashTrait for Hash {
     type Engine = HashEngine;

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -34,6 +34,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -124,6 +124,12 @@ impl<T: Tag> HashTrait for Hash<T> {
     }
 }
 
+impl<T> From<Hash<T>> for <Hash<T> as HashTrait>::Inner where T: Tag {
+    fn from(hash: Hash<T>) -> Self {
+        hash.into_inner()
+    }
+}
+
 /// Macro used to define a newtype tagged hash.
 /// It creates two public types:
 /// - a sha246t::Tag struct,

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -139,6 +139,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 64);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl HashTrait for Hash {
     type Engine = HashEngine;

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -208,6 +208,7 @@ hex_fmt_impl!(LowerHex, Hash);
 index_impl!(Hash);
 serde_impl!(Hash, 8);
 borrow_slice_impl!(Hash);
+from_hash_for_inner_impl!(Hash);
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/util.rs
+++ b/src/util.rs
@@ -144,6 +144,16 @@ macro_rules! engine_input_impl(
     )
 );
 
+macro_rules! from_hash_for_inner_impl(
+    ($hash:ty) => (
+        impl From<$hash> for <$hash as HashTrait>::Inner {
+            fn from(hash: $hash) -> Self {
+                hash.into_inner()
+            }
+        }
+    )
+);
+
 
 
 macro_rules! define_slice_to_be {


### PR DESCRIPTION
Hashes can be represented as fixed length arrays. That is in fact
what they are internally.
There is value in using Rust's visibility rules to enforce that
no every byte array is a valid hash.
However, every hash is certainly a valid byte array, hence it
should be easy to access their contents as such.

We add a `From` impl for any hash newtype for the inner byte array.
This makes it possible to pass hash-newtypes the way they are to
any function that needs a byte-array.

We also add a `From` impl for any inner hash type that allows us
to convert to the inner representation.

Both of these changes are especially useful from a broader ecosystem
perspective:

Because `From` and `Into` are part of the standard library, any
application or crate depends on them and can write functions that
support a form of method overloading by accepting anything that is
`Into<[u8; 32]>`.

Implementing these conversion traits on our types makes them
compatible with this pattern which results in less verbose APIs.