### PR TITLE
Provide an as_inner() for Hash types to get an array reference

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 cache: 
   cargo: true
   directories:
-  - cargo_web
+  - wasm
 
 rust:
   - stable
@@ -20,16 +20,16 @@ jobs:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y binutils-dev libunwind8-dev
+  - sudo apt-get install -y binutils-dev libunwind8-dev nodejs
 
 script:
   - |
       if [ "$FUZZ" = "true" ]; then
         cd fuzz && cargo test --verbose && ./travis-fuzz.sh;
       elif [ "$WASM" = "true" ]; then
-        CARGO_TARGET_DIR=cargo_web cargo install --force cargo-web
-        cargo web build --target=asmjs-unknown-emscripten
-        cargo web test --target=asmjs-unknown-emscripten --nodejs
+        CARGO_TARGET_DIR=wasm cargo install --verbose --force wasm-pack &&
+        sed -i 's/\[lib\]/[lib]\ncrate-type = ["cdylib", "rlib"]/' Cargo.toml &&
+        wasm-pack build && wasm-pack test --node
       else
         cargo build --verbose
         cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ serde_test = "1.0"
 version = "1.0"
 optional = true
 default-features = false
+
+[target.wasm32-unknown-unknown.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -77,6 +77,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -193,6 +193,10 @@ impl<T: HashTrait> HashTrait for Hmac<T> {
         self.0.into_inner()
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        self.0.as_inner()
+    }
+
     fn from_inner(inner: T::Inner) -> Self {
         Hmac(T::from_inner(inner))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,6 +127,9 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     /// Unwraps the hash and returns the underlying byte array
     fn into_inner(self) -> Self::Inner;
 
+    /// Unwraps the hash and returns a reference to the underlying byte array
+    fn as_inner(&self) -> &Self::Inner;
+
     /// Constructs a hash from the underlying byte array
     fn from_inner(inner: Self::Inner) -> Self;
 }
@@ -199,6 +202,11 @@ macro_rules! hash_newtype {
             #[inline]
             fn into_inner(self) -> Self::Inner {
                 self.0.into_inner()
+            }
+
+            #[inline]
+            fn as_inner(&self) -> &Self::Inner {
+                self.0.as_inner()
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,9 @@ macro_rules! hash_newtype {
         }
 
         impl ::std::str::FromStr for $newtype {
-            type Err = ::hex::Error;
+            type Err = $crate::hex::Error;
             fn from_str(s: &str) -> ::std::result::Result<$newtype, Self::Err> {
-                ::hex::FromHex::from_hex(s)
+                $crate::hex::FromHex::from_hex(s)
             }
         }
     };

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -135,6 +135,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -122,6 +122,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -494,6 +494,19 @@ mod tests {
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
         assert_tokens(&hash.readable(), &[Token::Str("ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c")]);
     }
+
+    #[cfg(target_arch = "wasm32")]
+    mod wasm_tests {
+        extern crate wasm_bindgen_test;
+        use super::*;
+        use self::wasm_bindgen_test::*;
+        #[wasm_bindgen_test]
+        fn sha256_tests() {
+            test();
+            midstate();
+            engine_with_state();
+        }
+    }
 }
 
 #[cfg(all(test, feature="unstable"))]

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -129,6 +129,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -73,6 +73,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -69,6 +69,10 @@ impl<T: Tag> HashTrait for Hash<T> {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner, PhantomData)
     }

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -180,6 +180,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -281,6 +281,10 @@ impl HashTrait for Hash {
         self.0
     }
 
+    fn as_inner(&self) -> &Self::Inner {
+        &self.0
+    }
+
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }


### PR DESCRIPTION
You can already trivially get a slice reference to the inner byte
array for hash types, but its occasionally nice to also be able to
get a direct reference to the inner byte array that isn't through a
fat pointer.