### PR TITLE
Removing unnecessary `core` and `serde` crate exports

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -50,9 +50,9 @@ pub trait ToHex {
 pub trait FromHex: Sized {
     /// Produce an object from a byte iterator
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-        where I: Iterator<Item=Result<u8, Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator;
+        where I: ::core::iter::Iterator<Item=Result<u8, Error>> +
+            ::core::iter::ExactSizeIterator +
+            ::core::iter::DoubleEndedIterator;
 
     /// Produce an object from a hex string
     fn from_hex(s: &str) -> Result<Self, Error> {
@@ -70,9 +70,9 @@ impl<T: fmt::LowerHex> ToHex for T {
 
 impl<T: Hash> FromHex for T {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-        where I: Iterator<Item=Result<u8, Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
+        where I: ::core::iter::Iterator<Item=Result<u8, Error>> +
+            ::core::iter::ExactSizeIterator +
+            ::core::iter::DoubleEndedIterator,
     {
         let inner;
         if Self::DISPLAY_BACKWARD {
@@ -115,7 +115,7 @@ fn chars_to_hex(hi: u8, lo: u8) -> Result<u8, Error> {
     Ok(ret as u8)
 }
 
-impl<'a> Iterator for HexIterator<'a> {
+impl<'a> ::core::iter::Iterator for HexIterator<'a> {
     type Item = Result<u8, Error>;
 
     fn next(&mut self) -> Option<Result<u8, Error>> {
@@ -130,7 +130,7 @@ impl<'a> Iterator for HexIterator<'a> {
     }
 }
 
-impl<'a> DoubleEndedIterator for HexIterator<'a> {
+impl<'a> ::core::iter::DoubleEndedIterator for HexIterator<'a> {
     fn next_back(&mut self) -> Option<Result<u8, Error>> {
         let lo = self.iter.next_back()?;
         let hi = self.iter.next_back().unwrap();
@@ -138,7 +138,7 @@ impl<'a> DoubleEndedIterator for HexIterator<'a> {
     }
 }
 
-impl<'a> ExactSizeIterator for HexIterator<'a> {}
+impl<'a> ::core::iter::ExactSizeIterator for HexIterator<'a> {}
 
 /// Output hex into an object implementing `fmt::Write`, which is usually more
 /// efficient than going through a `String` using `ToHex`.
@@ -189,9 +189,9 @@ impl ToHex for [u8] {
 #[cfg(any(test, feature = "std"))]
 impl FromHex for Vec<u8> {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-        where I: Iterator<Item=Result<u8, Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
+        where I: ::core::iter::Iterator<Item=Result<u8, Error>> +
+            ::core::iter::ExactSizeIterator +
+            ::core::iter::DoubleEndedIterator,
     {
         iter.collect()
     }
@@ -199,11 +199,11 @@ impl FromHex for Vec<u8> {
 
 macro_rules! impl_fromhex_array {
     ($len:expr) => {
-        impl FromHex for [u8; $len] {
-            fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-                where I: Iterator<Item=Result<u8, Error>> +
-                    ExactSizeIterator +
-                    DoubleEndedIterator,
+        impl $crate::hex::FromHex for [u8; $len] {
+            fn from_byte_iter<I>(iter: I) -> Result<Self, $crate::hex::Error>
+                where I: ::core::iter::Iterator<Item=Result<u8, $crate::hex::Error>> +
+                    ::core::iter::ExactSizeIterator +
+                    ::core::iter::DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];
@@ -212,7 +212,7 @@ macro_rules! impl_fromhex_array {
                     }
                     Ok(ret)
                 } else {
-                    Err(Error::InvalidLength(2 * $len, 2 * iter.len()))
+                    Err($crate::hex::Error::InvalidLength(2 * $len, 2 * iter.len()))
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
-#[cfg(any(test, feature="std"))] pub extern crate core;
-#[cfg(feature="serde")] pub extern crate serde;
+#[cfg(any(test, feature="std"))] extern crate core;
+#[cfg(feature="serde")] extern crate serde;
 #[cfg(all(test,feature="serde"))] extern crate serde_test;
 
 #[macro_use] mod util;

--- a/src/util.rs
+++ b/src/util.rs
@@ -29,8 +29,8 @@ macro_rules! hex_fmt_impl(
         hex_fmt_impl!($imp, $ty, );
     );
     ($imp:ident, $ty:ident, $($gen:ident: $gent:ident),*) => (
-        impl<$($gen: $gent),*> $crate::core::fmt::$imp for $ty<$($gen),*> {
-            fn fmt(&self, f: &mut $crate::core::fmt::Formatter) -> $crate::core::fmt::Result {
+        impl<$($gen: $gent),*> ::core::fmt::$imp for $ty<$($gen),*> {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                 use $crate::hex::{format_hex, format_hex_reverse};
                 if $ty::<$($gen),*>::DISPLAY_BACKWARD {
                     format_hex_reverse(&self.0, f)
@@ -49,37 +49,37 @@ macro_rules! index_impl(
         index_impl!($ty, );
     );
     ($ty:ident, $($gen:ident: $gent:ident),*) => (
-        impl<$($gen: $gent),*> $crate::core::ops::Index<usize> for $ty<$($gen),*> {
+        impl<$($gen: $gent),*> ::core::ops::Index<usize> for $ty<$($gen),*> {
             type Output = u8;
             fn index(&self, index: usize) -> &u8 {
                 &self.0[index]
             }
         }
 
-        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::Range<usize>> for $ty<$($gen),*> {
+        impl<$($gen: $gent),*> ::core::ops::Index<::core::ops::Range<usize>> for $ty<$($gen),*> {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::Range<usize>) -> &[u8] {
+            fn index(&self, index: ::core::ops::Range<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::RangeFrom<usize>> for $ty<$($gen),*> {
+        impl<$($gen: $gent),*> ::core::ops::Index<::core::ops::RangeFrom<usize>> for $ty<$($gen),*> {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::RangeFrom<usize>) -> &[u8] {
+            fn index(&self, index: ::core::ops::RangeFrom<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::RangeTo<usize>> for $ty<$($gen),*> {
+        impl<$($gen: $gent),*> ::core::ops::Index<::core::ops::RangeTo<usize>> for $ty<$($gen),*> {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::RangeTo<usize>) -> &[u8] {
+            fn index(&self, index: ::core::ops::RangeTo<usize>) -> &[u8] {
                 &self.0[index]
             }
         }
 
-        impl<$($gen: $gent),*> $crate::core::ops::Index<$crate::core::ops::RangeFull> for $ty<$($gen),*> {
+        impl<$($gen: $gent),*> ::core::ops::Index<::core::ops::RangeFull> for $ty<$($gen),*> {
             type Output = [u8];
-            fn index(&self, index: $crate::core::ops::RangeFull) -> &[u8] {
+            fn index(&self, index: ::core::ops::RangeFull) -> &[u8] {
                 &self.0[index]
             }
         }
@@ -93,19 +93,19 @@ macro_rules! borrow_slice_impl(
         borrow_slice_impl!($ty, );
     );
     ($ty:ident, $($gen:ident: $gent:ident),*) => (
-        impl<$($gen: $gent),*> $crate::core::borrow::Borrow<[u8]> for $ty<$($gen),*>  {
+        impl<$($gen: $gent),*> ::core::borrow::Borrow<[u8]> for $ty<$($gen),*>  {
             fn borrow(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl<$($gen: $gent),*> $crate::core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
+        impl<$($gen: $gent),*> ::core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
             fn as_ref(&self) -> &[u8] {
                 &self[..]
             }
         }
 
-        impl<$($gen: $gent),*> $crate::core::ops::Deref for $ty<$($gen),*> {
+        impl<$($gen: $gent),*> ::core::ops::Deref for $ty<$($gen),*> {
             type Target = [u8];
 
             fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
This was introduced by me some time ago when I was working on hashtype implementation in rust-bitcoin. However it's improper way of doing things, so I've fixed it now. Nevertheless it is a breaking change (since those who was relying on `core` exported by this library will now have to modify their code)