### PR TITLE
Doc comments + README amendments

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 # Bitcoin Hashes Library
 
 This is a simple, no-dependency library which implements the hash functions
-needed by Bitcoin. These are SHA1, SHA256, SHA256d, SHA512, and RIPEMD160. As an
-ancilliary thing, it exposes hexadecimal serialization and deserialization,
-since these are needed to display hashes anway.
+needed by Bitcoin. These are `Sha256`, `Sha256d` (double SHA-256), `Sha256t`
+(tagged SHA-256), `Sha512`, `Ripemd160` and `Hash160` (representing 
+bitcoin RIPEMD-160 over SHA-256). As an ancillary thing, it exposes hexadecimal 
+serialization and deserialization, since these are needed to display hashes 
+anyway.
 
 [Documentation](https://docs.rs/bitcoin_hashes/)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ anyway.
 [Documentation](https://docs.rs/bitcoin_hashes/)
 
 ## Minimum Supported Rust Version (MSRV)
-This library should always compile with any combination of features on **Rust 1.22**.
+This library should always compile with any combination of features on 
+**Rust 1.29**.
 
 
 ## Contributions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,11 @@
 //! # Rust Hashes Library
 //!
 //! This is a simple, no-dependency library which implements the hash functions
-//! needed by Bitcoin. These are SHA256, SHA256d, and RIPEMD160. As an ancillary
-//! thing, it exposes hexadecimal serialization and deserialization, since these
-//! are needed to display hashes anway.
+//! needed by Bitcoin. These are `Sha256`, `Sha256d` (double SHA-256), `Sha256t`
+//! (tagged SHA-256), `Sha512`, `Ripemd160` and `Hash160` (representing
+//! bitcoin RIPEMD-160 over SHA-256). As an ancillary thing, it exposes
+//! hexadecimal serialization and deserialization, since these are needed to
+//! display hashes anyway.
 //!
 
 // Coding conventions


### PR DESCRIPTION
Very tiny amendments: one error and more details on all hash types represented by the library. This also synchronize README with crate doc comments, which got out of sync with some previous commits. The final thing, we missed change MSRV in README (after changing it in crate description and travis config :)