### PR TITLE
Renaming Hash/Engine trait to Digest/Engine (implements #16)

### DIFF
--- a/fuzz/fuzz_targets/ripemd160.rs
+++ b/fuzz/fuzz_targets/ripemd160.rs
@@ -2,7 +2,7 @@
 extern crate bitcoin_hashes;
 extern crate crypto;
 
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{Digest as BitcoinDigest};
 use bitcoin_hashes::ripemd160;
 use crypto::digest::Digest;
 use crypto::ripemd160::Ripemd160;

--- a/fuzz/fuzz_targets/sha1.rs
+++ b/fuzz/fuzz_targets/sha1.rs
@@ -2,7 +2,7 @@
 extern crate bitcoin_hashes;
 extern crate crypto;
 
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{Digest as BitcoinDigest};
 use bitcoin_hashes::sha1;
 use crypto::digest::Digest;
 use crypto::sha1::Sha1;

--- a/fuzz/fuzz_targets/sha256.rs
+++ b/fuzz/fuzz_targets/sha256.rs
@@ -2,7 +2,7 @@
 extern crate bitcoin_hashes;
 extern crate crypto;
 
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{Digest as BitcoinDigest};
 use bitcoin_hashes::sha256;
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;

--- a/fuzz/fuzz_targets/sha512.rs
+++ b/fuzz/fuzz_targets/sha512.rs
@@ -2,7 +2,7 @@
 extern crate bitcoin_hashes;
 extern crate crypto;
 
-use bitcoin_hashes::Hash;
+use bitcoin_hashes::{Digest as BitcoinDigest};
 use bitcoin_hashes::sha512;
 use crypto::digest::Digest;
 use crypto::sha2::Sha512;

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -85,7 +85,7 @@ mod benches {
 
     use sha256;
     use sha512;
-    use Hash;
+    use Digest;
     use cmp::fixed_time_eq;
 
     #[bench]

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -23,7 +23,7 @@ use core::str;
 
 use sha256;
 use ripemd160;
-use Digest as HashTrait;
+use Digest;
 use Error;
 
 /// Output of the Bitcoin HASH160 hash function
@@ -44,7 +44,7 @@ impl str::FromStr for Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = sha256::HashEngine;
     type Inner = [u8; 20];
 

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -23,7 +23,7 @@ use core::str;
 
 use sha256;
 use ripemd160;
-use Hash as HashTrait;
+use Digest as HashTrait;
 use Error;
 
 /// Output of the Bitcoin HASH160 hash function
@@ -90,8 +90,8 @@ impl HashTrait for Hash {
 mod tests {
     use hash160;
     use hex::{FromHex, ToHex};
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[derive(Clone)]
     struct Test {
@@ -136,7 +136,7 @@ mod tests {
             for ch in test.input {
                 engine.input(&[ch]);
             }
-            let manual_hash = Hash::from_engine(engine);
+            let manual_hash = Digest::from_engine(engine);
             assert_eq!(hash, manual_hash);
             assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
         }
@@ -166,8 +166,8 @@ mod benches {
     use test::Bencher;
 
     use hash160;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn hash160_10(bh: & mut Bencher) {

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -16,7 +16,7 @@
 //!
 
 use core::{fmt, str};
-use Hash;
+use Digest;
 
 /// Hex decoding error
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -68,7 +68,7 @@ impl<T: fmt::LowerHex> ToHex for T {
     }
 }
 
-impl<T: Hash> FromHex for T {
+impl<T: Digest> FromHex for T {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
         where I: Iterator<Item=Result<u8, Error>> +
             ExactSizeIterator +
@@ -80,7 +80,7 @@ impl<T: Hash> FromHex for T {
         } else {
             inner = T::Inner::from_byte_iter(iter)?;
         }
-        Ok(Hash::from_inner(inner))
+        Ok(Digest::from_inner(inner))
     }
 }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -23,8 +23,8 @@ use core::{borrow, fmt, ops, str};
 #[cfg(feature="serde")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
+use DigestEngine as EngineTrait;
+use Digest as HashTrait;
 use Error;
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
@@ -225,7 +225,7 @@ impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
 mod tests {
     use sha256;
     #[cfg(feature="serde")] use sha512;
-    use {Hash, HashEngine, Hmac, HmacEngine};
+    use {Digest, DigestEngine, Hmac, HmacEngine};
 
     #[derive(Clone)]
     struct Test {
@@ -382,7 +382,7 @@ mod benches {
     use test::Bencher;
 
     use sha256;
-    use {Hmac, Hash, HashEngine};
+    use {Hmac, Digest, DigestEngine};
 
     #[bench]
     pub fn hmac_sha256_10(bh: & mut Bencher) {

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -40,11 +40,11 @@ impl<T: Digest + str::FromStr> str::FromStr for Hmac<T> {
 
 /// Pair of underlying hash midstates which represent the current state
 /// of an `HmacEngine`
-pub struct HmacMidState<T: Digest> {
+pub struct HmacMidstate<T: Digest> {
     /// Midstate of the inner hash engine
-    pub inner: <T::Engine as DigestEngine>::MidState,
+    pub inner: <T::Engine as DigestEngine>::Midstate,
     /// Midstate of the outer hash engine
-    pub outer: <T::Engine as DigestEngine>::MidState,
+    pub outer: <T::Engine as DigestEngine>::Midstate,
 }
 
 /// Pair of underyling hash engines, used for the inner and outer hash of HMAC
@@ -97,10 +97,10 @@ impl<T: Digest> HmacEngine<T> {
 }
 
 impl<T: Digest> DigestEngine for HmacEngine<T> {
-    type MidState = HmacMidState<T>;
+    type Midstate = HmacMidstate<T>;
 
-    fn midstate(&self) -> Self::MidState {
-        HmacMidState {
+    fn midstate(&self) -> Self::Midstate {
+        HmacMidstate {
             inner: self.iengine.midstate(),
             outer: self.oengine.midstate(),
         }

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -23,15 +23,15 @@ use core::{borrow, fmt, ops, str};
 #[cfg(feature="serde")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
-use DigestEngine as EngineTrait;
-use Digest as HashTrait;
+use DigestEngine;
+use Digest;
 use Error;
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Hmac<T: HashTrait>(T);
+pub struct Hmac<T: Digest>(T);
 
-impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {
+impl<T: Digest + str::FromStr> str::FromStr for Hmac<T> {
     type Err = <T as str::FromStr>::Err;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Hmac(str::FromStr::from_str(s)?))
@@ -40,27 +40,27 @@ impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {
 
 /// Pair of underlying hash midstates which represent the current state
 /// of an `HmacEngine`
-pub struct HmacMidState<T: HashTrait> {
+pub struct HmacMidState<T: Digest> {
     /// Midstate of the inner hash engine
-    pub inner: <T::Engine as EngineTrait>::MidState,
+    pub inner: <T::Engine as DigestEngine>::MidState,
     /// Midstate of the outer hash engine
-    pub outer: <T::Engine as EngineTrait>::MidState,
+    pub outer: <T::Engine as DigestEngine>::MidState,
 }
 
 /// Pair of underyling hash engines, used for the inner and outer hash of HMAC
 #[derive(Clone)]
-pub struct HmacEngine<T: HashTrait> {
+pub struct HmacEngine<T: Digest> {
     iengine: T::Engine,
     oengine: T::Engine,
 }
 
-impl<T: HashTrait> Default for HmacEngine<T> {
+impl<T: Digest> Default for HmacEngine<T> {
     fn default() -> Self {
         HmacEngine::new(&[])
     }
 }
 
-impl<T: HashTrait> HmacEngine<T> {
+impl<T: Digest> HmacEngine<T> {
     /// Construct a new keyed HMAC with the given key. We only support underlying hashes
     /// whose block sizes are ≤ 128 bytes; larger hashes will result in panics.
     pub fn new(key: &[u8]) -> HmacEngine<T> {
@@ -69,12 +69,12 @@ impl<T: HashTrait> HmacEngine<T> {
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
         let mut ret = HmacEngine {
-            iengine: <T as HashTrait>::engine(),
-            oengine: <T as HashTrait>::engine(),
+            iengine: <T as Digest>::engine(),
+            oengine: <T as Digest>::engine(),
         };
 
         if key.len() > T::Engine::BLOCK_SIZE {
-            let hash = <T as HashTrait>::hash(key);
+            let hash = <T as Digest>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(&hash[..]) {
                 *b_i ^= *b_h;
             }
@@ -90,13 +90,13 @@ impl<T: HashTrait> HmacEngine<T> {
             }
         };
 
-        EngineTrait::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
-        EngineTrait::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
+        DigestEngine::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
+        DigestEngine::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
         ret
     }
 }
 
-impl<T: HashTrait> EngineTrait for HmacEngine<T> {
+impl<T: Digest> DigestEngine for HmacEngine<T> {
     type MidState = HmacMidState<T>;
 
     fn midstate(&self) -> Self::MidState {
@@ -117,66 +117,66 @@ impl<T: HashTrait> EngineTrait for HmacEngine<T> {
     }
 }
 
-impl<T: HashTrait> fmt::Debug for Hmac<T> {
+impl<T: Digest> fmt::Debug for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
     }
 }
 
-impl<T: HashTrait> fmt::Display for Hmac<T> {
+impl<T: Digest> fmt::Display for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<T: HashTrait> fmt::LowerHex for Hmac<T> {
+impl<T: Digest> fmt::LowerHex for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
-impl<T: HashTrait> ops::Index<usize> for Hmac<T> {
+impl<T: Digest> ops::Index<usize> for Hmac<T> {
     type Output = u8;
     fn index(&self, index: usize) -> &u8 {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::Range<usize>> for Hmac<T> {
+impl<T: Digest> ops::Index<ops::Range<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::Range<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::RangeFrom<usize>> for Hmac<T> {
+impl<T: Digest> ops::Index<ops::RangeFrom<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::RangeTo<usize>> for Hmac<T> {
+impl<T: Digest> ops::Index<ops::RangeTo<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeTo<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::RangeFull> for Hmac<T> {
+impl<T: Digest> ops::Index<ops::RangeFull> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFull) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> borrow::Borrow<[u8]> for Hmac<T> {
+impl<T: Digest> borrow::Borrow<[u8]> for Hmac<T> {
     fn borrow(&self) -> &[u8] {
         &self[..]
     }
 }
 
-impl<T: HashTrait> HashTrait for Hmac<T> {
+impl<T: Digest> Digest for Hmac<T> {
     type Engine = HmacEngine<T>;
     type Inner = T::Inner;
 
@@ -207,14 +207,14 @@ impl<T: HashTrait> HashTrait for Hmac<T> {
 }
 
 #[cfg(feature="serde")]
-impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
+impl<T: Digest + Serialize> Serialize for Hmac<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(&self.0, s)
     }
 }
 
 #[cfg(feature="serde")]
-impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
+impl<'de, T: Digest + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Hmac<T>, D::Error> {
         let inner = Deserialize::deserialize(d)?;
         Ok(Hmac(inner))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@ pub use error::Error;
 /// any conditions.
 pub trait DigestEngine: Clone + Default {
     /// Byte array representing the internal state of the hash engine
-    type MidState;
+    type Midstate;
 
     /// Outputs the midstate of the hash engine. This function should not be
     /// used directly unless you really know what you're doing.
-    fn midstate(&self) -> Self::MidState;
+    fn midstate(&self) -> Self::Midstate;
 
     /// Length of the hash's internal block size, in bytes
     const BLOCK_SIZE: usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use error::Error;
 /// A hashing engine which bytes can be serialized into. It is expected
 /// to implement the `io::Write` trait, but to never return errors under
 /// any conditions.
-pub trait HashEngine: Clone + Default {
+pub trait DigestEngine: Clone + Default {
     /// Byte array representing the internal state of the hash engine
     type MidState;
 
@@ -84,7 +84,7 @@ pub trait HashEngine: Clone + Default {
 }
 
 /// Trait which applies to hashes of all types
-pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
+pub trait Digest: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     hash::Hash + fmt::Debug + fmt::Display + fmt::LowerHex +
     ops::Index<ops::RangeFull, Output = [u8]> +
     ops::Index<ops::RangeFrom<usize>, Output = [u8]> +
@@ -96,7 +96,7 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
     /// A hashing engine which bytes can be serialized into. It is expected
     /// to implement the `io::Write` trait, and to never return errors under
     /// any conditions.
-    type Engine: HashEngine;
+    type Engine: DigestEngine;
 
     /// The byte array that represents the hash internally
     type Inner: hex::FromHex;
@@ -141,7 +141,7 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
 #[macro_export]
 macro_rules! hash_newtype {
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta) => {
-        hash_newtype!($newtype, $hash, $len, $docs, <$hash as $crate::Hash>::DISPLAY_BACKWARD);
+        hash_newtype!($newtype, $hash, $len, $docs, <$hash as $crate::Digest>::DISPLAY_BACKWARD);
     };
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta, $reverse:expr) => {
         #[$docs]
@@ -181,25 +181,25 @@ macro_rules! hash_newtype {
             }
         }
 
-        impl $crate::Hash for $newtype {
-            type Engine = <$hash as $crate::Hash>::Engine;
-            type Inner = <$hash as $crate::Hash>::Inner;
+        impl $crate::Digest for $newtype {
+            type Engine = <$hash as $crate::Digest>::Engine;
+            type Inner = <$hash as $crate::Digest>::Inner;
 
-            const LEN: usize = <$hash as $crate::Hash>::LEN;
+            const LEN: usize = <$hash as $crate::Digest>::LEN;
             const DISPLAY_BACKWARD: bool = $reverse;
 
             fn from_engine(e: Self::Engine) -> Self {
-                Self::from(<$hash as $crate::Hash>::from_engine(e))
+                Self::from(<$hash as $crate::Digest>::from_engine(e))
             }
 
             #[inline]
             fn from_slice(sl: &[u8]) -> Result<$newtype, $crate::Error> {
-                Ok($newtype(<$hash as $crate::Hash>::from_slice(sl)?))
+                Ok($newtype(<$hash as $crate::Digest>::from_slice(sl)?))
             }
 
             #[inline]
             fn from_inner(inner: Self::Inner) -> Self {
-                $newtype(<$hash as $crate::Hash>::from_inner(inner))
+                $newtype(<$hash as $crate::Digest>::from_inner(inner))
             }
 
             #[inline]
@@ -224,7 +224,7 @@ macro_rules! hash_newtype {
 
 #[cfg(test)]
 mod test {
-    use Hash;
+    use Digest;
     hash_newtype!(TestNewtype, ::sha256d::Hash, 32, doc="A test newtype");
     hash_newtype!(TestNewtype2, ::sha256d::Hash, 32, doc="A test newtype");
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -21,8 +21,8 @@
 
 use core::{cmp, str};
 
-use DigestEngine as EngineTrait;
-use Digest as HashTrait;
+use DigestEngine;
+use Digest;
 use Error;
 use util;
 
@@ -46,7 +46,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl DigestEngine for HashEngine {
     type MidState = [u8; 20];
 
     #[cfg(not(feature = "fuzztarget"))]
@@ -92,7 +92,7 @@ impl str::FromStr for Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -21,8 +21,8 @@
 
 use core::{cmp, str};
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
+use DigestEngine as EngineTrait;
+use Digest as HashTrait;
 use Error;
 use util;
 
@@ -445,8 +445,8 @@ impl HashEngine {
 mod tests {
     use ripemd160;
     use hex::{FromHex, ToHex};
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[derive(Clone)]
     struct Test {
@@ -549,8 +549,8 @@ mod benches {
     use test::Bencher;
 
     use ripemd160;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn ripemd160_10(bh: & mut Bencher) {

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -47,7 +47,7 @@ impl Default for HashEngine {
 }
 
 impl DigestEngine for HashEngine {
-    type MidState = [u8; 20];
+    type Midstate = [u8; 20];
 
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> [u8; 20] {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -16,8 +16,8 @@
 
 use core::{cmp, str};
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
+use DigestEngine as EngineTrait;
+use Digest as HashTrait;
 use Error;
 use util;
 
@@ -183,8 +183,8 @@ impl HashEngine {
 mod tests {
     use sha1;
     use hex::{FromHex, ToHex};
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[derive(Clone)]
     struct Test {
@@ -274,8 +274,8 @@ mod benches {
     use test::Bencher;
 
     use sha1;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn sha1_10(bh: & mut Bencher) {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -16,8 +16,8 @@
 
 use core::{cmp, str};
 
-use DigestEngine as EngineTrait;
-use Digest as HashTrait;
+use DigestEngine;
+use Digest;
 use Error;
 use util;
 
@@ -41,7 +41,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl DigestEngine for HashEngine {
     type MidState = [u8; 20];
 
     #[cfg(not(feature = "fuzztarget"))]
@@ -87,7 +87,7 @@ impl str::FromStr for Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -42,7 +42,7 @@ impl Default for HashEngine {
 }
 
 impl DigestEngine for HashEngine {
-    type MidState = [u8; 20];
+    type Midstate = [u8; 20];
 
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> [u8; 20] {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -17,8 +17,8 @@
 use core::{cmp, str};
 
 use hex;
-use DigestEngine as EngineTrait;
-use Digest as HashTrait;
+use DigestEngine;
+use Digest;
 use Error;
 use util;
 
@@ -42,7 +42,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl DigestEngine for HashEngine {
     type MidState = Midstate;
 
     #[cfg(not(feature = "fuzztarget"))]
@@ -88,7 +88,7 @@ index_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 32];
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -17,8 +17,8 @@
 use core::{cmp, str};
 
 use hex;
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
+use DigestEngine as EngineTrait;
+use Digest as HashTrait;
 use Error;
 use util;
 
@@ -344,7 +344,7 @@ impl HashEngine {
 mod tests {
     use sha256;
     use hex::{FromHex, ToHex};
-    use {Hash, HashEngine};
+    use {Digest, DigestEngine};
 
     #[derive(Clone)]
     struct Test {
@@ -518,8 +518,8 @@ mod benches {
     use test::Bencher;
 
     use sha256;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn sha256_10(bh: & mut Bencher) {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -43,7 +43,7 @@ impl Default for HashEngine {
 }
 
 impl DigestEngine for HashEngine {
-    type MidState = Midstate;
+    type Midstate = Midstate;
 
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> Midstate {

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -17,7 +17,7 @@
 use core::str;
 
 use sha256;
-use Hash as HashTrait;
+use Digest as HashTrait;
 use Error;
 
 /// Output of the SHA256d hash function
@@ -86,8 +86,8 @@ impl HashTrait for Hash {
 mod tests {
     use sha256d;
     use hex::{FromHex, ToHex};
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
 #[derive(Clone)]
     struct Test {
@@ -153,8 +153,8 @@ mod benches {
     use test::Bencher;
 
     use sha256d;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn sha256d_10(bh: & mut Bencher) {

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -17,7 +17,7 @@
 use core::str;
 
 use sha256;
-use Digest as HashTrait;
+use Digest;
 use Error;
 
 /// Output of the SHA256d hash function
@@ -38,7 +38,7 @@ impl str::FromStr for Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = sha256::HashEngine;
     type Inner = [u8; 32];
 

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -17,7 +17,7 @@
 use core::marker::PhantomData;
 
 use sha256;
-use Digest as HashTrait;
+use Digest;
 #[allow(unused)]
 use Error;
 
@@ -38,7 +38,7 @@ hex_fmt_impl!(LowerHex, Hash, T:Tag);
 index_impl!(Hash, T:Tag);
 borrow_slice_impl!(Hash, T:Tag);
 
-impl<T: Tag> HashTrait for Hash<T> {
+impl<T: Tag> Digest for Hash<T> {
     type Engine = sha256::HashEngine;
     type Inner = [u8; 32];
 

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -17,7 +17,7 @@
 use core::marker::PhantomData;
 
 use sha256;
-use Hash as HashTrait;
+use Digest as HashTrait;
 #[allow(unused)]
 use Error;
 
@@ -159,7 +159,7 @@ impl<'de, T: Tag> ::serde::Deserialize<'de> for Hash<T> {
 
 #[cfg(test)]
 mod tests {
-    use ::{Hash, sha256, sha256t};
+    use ::{Digest, sha256, sha256t};
     use ::hex::ToHex;
 
     #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default, Hash)]

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -50,7 +50,7 @@ impl Default for HashEngine {
 }
 
 impl DigestEngine for HashEngine {
-    type MidState = [u8; 64];
+    type Midstate = [u8; 64];
 
     #[cfg(not(feature = "fuzztarget"))]
     fn midstate(&self) -> [u8; 64] {

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -21,8 +21,8 @@
 
 use core::{cmp, hash, str};
 
-use DigestEngine as EngineTrait;
-use Digest as HashTrait;
+use DigestEngine;
+use Digest;
 use Error;
 use util;
 
@@ -49,7 +49,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl DigestEngine for HashEngine {
     type MidState = [u8; 64];
 
     #[cfg(not(feature = "fuzztarget"))]
@@ -136,7 +136,7 @@ index_impl!(Hash);
 serde_impl!(Hash, 64);
 borrow_slice_impl!(Hash);
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 64];
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -21,8 +21,8 @@
 
 use core::{cmp, hash, str};
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
+use DigestEngine as EngineTrait;
+use Digest as HashTrait;
 use Error;
 use util;
 
@@ -334,8 +334,8 @@ impl HashEngine {
 mod tests {
     use sha512;
     use hex::{FromHex, ToHex};
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[derive(Clone)]
     struct Test {
@@ -443,8 +443,8 @@ mod benches {
     use test::Bencher;
 
     use sha512;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn sha512_10(bh: & mut Bencher) {

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -140,7 +140,7 @@ impl Default for HashEngine {
 }
 
 impl DigestEngine for HashEngine {
-    type MidState = State;
+    type Midstate = State;
 
     fn midstate(&self) -> State {
         self.state.clone()

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -22,8 +22,8 @@
 use core::{cmp, mem, ptr, str};
 
 use Error;
-use Digest as HashTrait;
-use DigestEngine as EngineTrait;
+use DigestEngine;
+use Digest;
 use util;
 
 macro_rules! compress {
@@ -139,7 +139,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl DigestEngine for HashEngine {
     type MidState = State;
 
     fn midstate(&self) -> State {
@@ -255,7 +255,7 @@ impl Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl Digest for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 8];
 
@@ -322,7 +322,6 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use Digest as HashTrait;
 
     #[test]
     fn test_siphash_2_4() {

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -22,8 +22,8 @@
 use core::{cmp, mem, ptr, str};
 
 use Error;
-use Hash as HashTrait;
-use HashEngine as EngineTrait;
+use Digest as HashTrait;
+use DigestEngine as EngineTrait;
 use util;
 
 macro_rules! compress {
@@ -322,7 +322,7 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use Hash as HashTrait;
+    use Digest as HashTrait;
 
     #[test]
     fn test_siphash_2_4() {
@@ -416,8 +416,8 @@ mod benches {
     use test::Bencher;
 
     use siphash24;
-    use Hash;
-    use HashEngine;
+    use Digest;
+    use DigestEngine;
 
     #[bench]
     pub fn siphash24_1ki(bh: &mut Bencher) {

--- a/src/std_impls.rs
+++ b/src/std_impls.rs
@@ -19,7 +19,7 @@
 use std::{error, io};
 
 use {hex, sha1, sha256, sha512, ripemd160, siphash24};
-use HashEngine;
+use DigestEngine;
 use Error;
 
 impl error::Error for Error {
@@ -82,7 +82,7 @@ mod tests {
     use std::io::Write;
 
     use {sha1, sha256, sha256d, sha512, ripemd160, hash160, siphash24};
-    use Hash;
+    use Digest;
 
     macro_rules! write_test {
         ($mod:ident, $exp_empty:expr, $exp_256:expr, $exp_64k:expr,) => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -120,14 +120,14 @@ macro_rules! engine_input_impl(
         #[cfg(not(feature = "fuzztarget"))]
         fn input(&mut self, mut inp: &[u8]) {
             while !inp.is_empty() {
-                let buf_idx = self.length % <Self as EngineTrait>::BLOCK_SIZE;
-                let rem_len = <Self as EngineTrait>::BLOCK_SIZE - buf_idx;
+                let buf_idx = self.length % <Self as DigestEngine>::BLOCK_SIZE;
+                let rem_len = <Self as DigestEngine>::BLOCK_SIZE - buf_idx;
                 let write_len = cmp::min(rem_len, inp.len());
 
                 self.buffer[buf_idx..buf_idx + write_len]
                     .copy_from_slice(&inp[..write_len]);
                 self.length += write_len;
-                if self.length % <Self as EngineTrait>::BLOCK_SIZE == 0 {
+                if self.length % <Self as DigestEngine>::BLOCK_SIZE == 0 {
                     self.process_block();
                 }
                 inp = &inp[write_len..];

--- a/src/util.rs
+++ b/src/util.rs
@@ -211,7 +211,7 @@ define_le_to_array!(u64_to_array_le, u64, 8);
 
 #[cfg(test)]
 mod test {
-    use Hash;
+    use Digest;
     use sha256;
     use super::*;
 


### PR DESCRIPTION
Seems there was an agreement on better trait names, reached in https://github.com/rust-bitcoin/bitcoin_hashes/issues/16, but never implemented. This PR implements it, plus as a separate second and third commits it
- removes unnecessary `use Digest as HashTrait` and `use DigestEngine as EngineTrait`
- renames all cases `MidState` to `Midstate` to match naming of `fn midstate()` (according to Rust naming conventions, https://doc.rust-lang.org/1.0.0/style/style/naming/README.html, we have to either use `type MidState` with `fn mid_state`, if we think it's two different words, or `type Midstate` with `fn midstate()`, if it is a single word)