### PR TITLE
Implement Hash::engine() for hash newtypes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,10 @@ macro_rules! hash_newtype {
             const LEN: usize = <$hash as $crate::Hash>::LEN;
             const DISPLAY_BACKWARD: bool = $reverse;
 
+            fn engine() -> Self::Engine {
+                <$hash as $crate::Hash>::engine()
+            }
+
             fn from_engine(e: Self::Engine) -> Self {
                 Self::from(<$hash as $crate::Hash>::from_engine(e))
             }


### PR DESCRIPTION
Instead of the default implementation of `Engine::default()`.

This is needed to make newtypes with with `sha256t` tagged hashes for taproot.