### PR TITLE
Add Optional JSONSchema Support for Hash Types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,14 @@ fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noop
 
 [dev-dependencies]
 serde_test = "1.0"
+serde_json = "1.0"
+jsonschema-valid = "0.4.0"
 
 [dependencies]
+
+[dependencies.schemars]
+version = "0.8.0"
+optional = true
 
 [dependencies.serde]
 version = "1.0"

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -28,7 +28,13 @@ use Error;
 
 /// Output of the Bitcoin HASH160 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Hash([u8; 20]);
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Hash(
+    #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_20"))]
+    [u8; 20]
+);
+
+
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
@@ -145,6 +151,7 @@ mod tests {
     #[cfg(feature="serde")]
     #[test]
     fn ripemd_serde() {
+
         use serde_test::{Configure, Token, assert_tokens};
 
         static HASH_BYTES: [u8; 20] = [
@@ -158,6 +165,24 @@ mod tests {
         let hash = hash160::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
         assert_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
+    }
+
+    #[cfg(all(feature = "schemars",feature = "serde"))]
+    #[test]
+    fn jsonschema_accurate() {
+        static HASH_BYTES: [u8; 20] = [
+            0x13, 0x20, 0x72, 0xdf,
+            0x69, 0x09, 0x33, 0x83,
+            0x5e, 0xb8, 0xb6, 0xad,
+            0x0b, 0x77, 0xe7, 0xb6,
+            0xf1, 0x4a, 0xca, 0xd7,
+        ];
+
+        let hash = hash160::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
+        let js = serde_json::from_str(&serde_json::to_string(&hash).unwrap()).unwrap();
+        let s  = schemars::schema_for! (hash160::Hash);
+        let schema = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert!(jsonschema_valid::Config::from_schema(&schema, None).unwrap().validate(&js).is_ok());
     }
 }
 
@@ -191,6 +216,7 @@ mod benches {
 
     #[bench]
     pub fn hash160_64k(bh: & mut Bencher) {
+
         let mut engine = hash160::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -29,6 +29,8 @@ use Error;
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
 pub struct Hmac<T: HashTrait>(T);
 
 impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {
@@ -374,6 +376,27 @@ mod tests {
                  fffb8088ccf85497121ad4499e0845b876f6dd6640088a2f0b2d8a600bdf4c0c"
             )],
         );
+    }
+
+    #[cfg(all(feature = "schemars",feature = "serde"))]
+    #[test]
+    fn jsonschema_accurate() {
+        static HASH_BYTES: [u8; 64] = [
+            0x8b, 0x41, 0xe1, 0xb7, 0x8a, 0xd1, 0x15, 0x21,
+            0x11, 0x3c, 0x52, 0xff, 0x18, 0x2a, 0x1b, 0x8e,
+            0x0a, 0x19, 0x57, 0x54, 0xaa, 0x52, 0x7f, 0xcd,
+            0x00, 0xa4, 0x11, 0x62, 0x0b, 0x46, 0xf2, 0x0f,
+            0xff, 0xfb, 0x80, 0x88, 0xcc, 0xf8, 0x54, 0x97,
+            0x12, 0x1a, 0xd4, 0x49, 0x9e, 0x08, 0x45, 0xb8,
+            0x76, 0xf6, 0xdd, 0x66, 0x40, 0x08, 0x8a, 0x2f,
+            0x0b, 0x2d, 0x8a, 0x60, 0x0b, 0xdf, 0x4c, 0x0c,
+        ];
+
+        let hash = Hmac::<sha512::Hash>::from_slice(&HASH_BYTES).expect("right number of bytes");
+        let js = serde_json::from_str(&serde_json::to_string(&hash).unwrap()).unwrap();
+        let s  = schemars::schema_for! (Hmac::<sha512::Hash>);
+        let schema = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert!(jsonschema_valid::Config::from_schema(&schema, None).unwrap().validate(&js).is_ok());
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@
 #[cfg(feature="serde")] pub extern crate serde;
 #[cfg(all(test,feature="serde"))] extern crate serde_test;
 
+#[cfg(feature = "schemars")] extern crate schemars;
+
 #[macro_use] mod util;
 #[macro_use] mod serde_macros;
 #[cfg(any(test, feature = "std"))] mod std_impls;

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -71,7 +71,11 @@ impl EngineTrait for HashEngine {
 
 /// Output of the SHA1 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Hash([u8; 20]);
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Hash(
+    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_20"))]
+    [u8; 20]
+);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
@@ -266,6 +270,24 @@ mod tests {
         let hash = sha1::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
         assert_tokens(&hash.readable(), &[Token::Str("132072df690933835eb8b6ad0b77e7b6f14acad7")]);
+    }
+
+    #[cfg(all(feature = "schemars",feature = "serde"))]
+    #[test]
+    fn jsonschema_accurate() {
+        static HASH_BYTES: [u8; 20] = [
+            0x13, 0x20, 0x72, 0xdf,
+            0x69, 0x09, 0x33, 0x83,
+            0x5e, 0xb8, 0xb6, 0xad,
+            0x0b, 0x77, 0xe7, 0xb6,
+            0xf1, 0x4a, 0xca, 0xd7,
+        ];
+
+        let hash = sha1::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
+        let js = serde_json::from_str(&serde_json::to_string(&hash).unwrap()).unwrap();
+        let s  = schemars::schema_for! (sha1::Hash);
+        let schema = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert!(jsonschema_valid::Config::from_schema(&schema, None).unwrap().validate(&js).is_ok());
     }
 }
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -22,7 +22,11 @@ use Error;
 
 /// Output of the SHA256d hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Hash([u8; 32]);
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Hash(
+    #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_32"))]
+    [u8; 32]
+);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
@@ -146,6 +150,24 @@ input: &'static str,
         assert_tokens(&hash.compact(), &[Token::BorrowedBytes(&HASH_BYTES[..])]);
         assert_tokens(&hash.readable(), &[Token::Str("6cfb35868c4465b7c289d7d5641563aa973db6a929655282a7bf95c8257f53ef")]);
     }
+
+    #[cfg(all(feature = "schemars",feature = "serde"))]
+    #[test]
+    fn jsonschema_accurate() {
+        static HASH_BYTES: [u8; 32] = [
+            0xef, 0x53, 0x7f, 0x25, 0xc8, 0x95, 0xbf, 0xa7,
+            0x82, 0x52, 0x65, 0x29, 0xa9, 0xb6, 0x3d, 0x97,
+            0xaa, 0x63, 0x15, 0x64, 0xd5, 0xd7, 0x89, 0xc2,
+            0xb7, 0x65, 0x44, 0x8c, 0x86, 0x35, 0xfb, 0x6c,
+        ];
+
+        let hash = sha256d::Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
+        let js = serde_json::from_str(&serde_json::to_string(&hash).unwrap()).unwrap();
+        let s  = schemars::schema_for! (sha256d::Hash);
+        let schema = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert!(jsonschema_valid::Config::from_schema(&schema, None).unwrap().validate(&js).is_ok());
+    }
+
 }
 
 #[cfg(all(test, feature="unstable"))]

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -196,7 +196,11 @@ impl EngineTrait for HashEngine {
 
 /// Output of the SipHash24 hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
-pub struct Hash([u8; 8]);
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Hash(
+    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_8"))]
+    [u8; 8]
+);
 
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
@@ -408,6 +412,20 @@ mod tests {
             assert_eq!(vec, inc, "vec #{}", i);
             state_inc.input(&[i as u8]);
         }
+    }
+
+    #[cfg(all(feature = "schemars",feature = "serde"))]
+    #[test]
+    fn jsonschema_accurate() {
+        static HASH_BYTES: [u8; 8] = [
+            0x8b, 0x41, 0xe1, 0xb7, 0x8a, 0xd1, 0x15, 0x21,
+        ];
+
+        let hash = Hash::from_slice(&HASH_BYTES).expect("right number of bytes");
+        let js = serde_json::from_str(&serde_json::to_string(&hash).unwrap()).unwrap();
+        let s  = schemars::schema_for! (Hash);
+        let schema = serde_json::from_str(&serde_json::to_string(&s).unwrap()).unwrap();
+        assert!(jsonschema_valid::Config::from_schema(&schema, None).unwrap().validate(&js).is_ok());
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -209,6 +209,29 @@ define_slice_to_le!(slice_to_u64_le, u64);
 define_le_to_array!(u32_to_array_le, u32, 4);
 define_le_to_array!(u64_to_array_le, u64, 8);
 
+#[cfg(feature = "schemars")]
+pub mod json_hex_string {
+    use schemars::schema::{Schema, SchemaObject};
+    use schemars::{gen::SchemaGenerator, JsonSchema};
+    macro_rules! define_custom_hex {
+        ($name:ident, $len:expr) => {
+            pub fn $name(gen: &mut SchemaGenerator) -> Schema {
+                let mut schema: SchemaObject = <String>::json_schema(gen).into();
+                schema.string = Some(Box::new(schemars::schema::StringValidation {
+                    max_length: Some($len * 2),
+                    min_length: Some($len * 2),
+                    pattern: Some("[0-9a-fA-F]+".to_owned()),
+                }));
+                schema.into()
+            }
+        };
+    }
+    define_custom_hex!(len_8, 8);
+    define_custom_hex!(len_20, 20);
+    define_custom_hex!(len_32, 32);
+    define_custom_hex!(len_64, 64);
+}
+
 #[cfg(test)]
 mod test {
     use Hash;


### PR DESCRIPTION
This patch adds functionality to optionally be able to generate json schema types.

The generated schemas are not 'complete' verification rules (as they don't know about things like length), but they can be useful for describing an expected return type from e.g. a web client. Future work can add a custom serializer (no great support for declaring this like serde attrs yet) which adds a length validation https://graham.cool/schemars/examples/7-custom_serialization/ and regex to ensure that all fields are hex hashes of appropriate length.

Schemars in particular is a relatively simple library (I've looked it over casually) and has only one new dependency compared to the rust bitcoin crate (dyn-clone).

While this is a WIP, it can be merged. But I'd love to get conceptual feedback here as the plan would be to introduce similar patches across the entire rust-bitcoin project so that any type (transactions, witnesses, blocks, etc) can get automatically generated schemas.


