### PR TITLE
fix serde macro visibility issue, release 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 0.9.2 - 2020-10-16
+
+* Fix visibility issue with serde macros
+
 # 0.9.1 - 2020-10-07
 
 * Add `FromStr` impl to `sha256t::Hash`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 description = "Hash functions used by rust-bitcoin which support rustc 1.29.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 #[cfg(feature = "schemars")] extern crate schemars;
 
 #[macro_use] mod util;
-#[macro_use] mod serde_macros;
+#[macro_use] pub mod serde_macros;
 #[cfg(any(test, feature = "std"))] mod std_impls;
 pub mod error;
 pub mod hex;

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -1,4 +1,21 @@
+// Bitcoin Hashes Library
+// Written in 2018 by
+//   Andrew Poelstra <apoelstra@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+//! Macros for serde trait impls, and supporting code
+
 #[cfg(feature = "serde")]
+/// Functions used by serde impls of all hashes
 pub mod serde_details {
     use Error;
 
@@ -60,6 +77,7 @@ pub mod serde_details {
         }
     }
 
+    /// Default serialization/deserialization methods
     pub trait SerdeHash
     where
         Self: Sized
@@ -68,9 +86,13 @@ pub mod serde_details {
             + std::ops::Index<usize, Output = u8>
             + std::ops::Index<std::ops::RangeFull, Output = [u8]>
     {
+        /// Size, in bits, of the hash
         const N: usize;
 
+        /// helper function to turn a deserialized slice into the correct hash type
         fn from_slice_delegated(sl: &[u8]) -> Result<Self, Error>;
+
+        /// serde serialization
         fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
             if s.is_human_readable() {
                 s.serialize_str(&self.to_hex())
@@ -79,6 +101,7 @@ pub mod serde_details {
             }
         }
 
+        /// serde deserialization
         fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
             if d.is_human_readable() {
                 d.deserialize_str(HexVisitor::<Self>(PhantomData))


### PR DESCRIPTION
Our last release broke the build for rust-bitcoin iand anything else using the serde impls in this crate) because it moved internals of the serde macros into the non-public `serde_macros` module. This PR exposes the module and bumps the version to fix downstream users.