### PR TITLE
more serde_macro fixes; bump version to 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+# 0.9.2 - 2020-10-18
+
+* Fix rustc 1.29.0 downstream issues with serde macros
+
 # 0.9.2 - 2020-10-16
 
 * Fix visibility issue with serde macros

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 description = "Hash functions used by rust-bitcoin which support rustc 1.29.0"

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -19,18 +19,19 @@
 pub mod serde_details {
     use Error;
 
-    use std::marker::PhantomData;
+    use core::marker::PhantomData;
+    use core::{fmt, ops};
     struct HexVisitor<ValueT>(PhantomData<ValueT>);
     use serde::{de, Serializer, Deserializer};
-    use hex;
+    use hex::{FromHex, ToHex};
 
     impl<'de, ValueT> de::Visitor<'de> for HexVisitor<ValueT>
     where
-        ValueT: hex::FromHex,
+        ValueT: FromHex,
     {
         type Value = ValueT;
 
-        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("an ASCII hex string")
         }
 
@@ -62,7 +63,7 @@ pub mod serde_details {
     where ValueT : SerdeHash {
         type Value = ValueT;
 
-        fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             formatter.write_str("a bytestring")
         }
 
@@ -81,10 +82,10 @@ pub mod serde_details {
     pub trait SerdeHash
     where
         Self: Sized
-            + hex::ToHex
-            + hex::FromHex
-            + std::ops::Index<usize, Output = u8>
-            + std::ops::Index<std::ops::RangeFull, Output = [u8]>
+            + ToHex
+            + FromHex
+            + ops::Index<usize, Output = u8>
+            + ops::Index<ops::RangeFull, Output = [u8]>
     {
         /// Size, in bits, of the hash
         const N: usize;


### PR DESCRIPTION
Still having rust-bitcoin build failures, this time with rustc 1.29.0, due to some module path import rule changes. Cleaned these up a bit; also replaced `std` by `core` everywhere; I don't know if we support serde+no_std but it's good to be consistent.