### PR TITLE
Reformat the manifest dependency section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,21 +21,14 @@ serde-std = ["serde/std"]
 unstable = []  # for benchmarking
 fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noops, DON'T USE THIS
 
+[dependencies]
+serde = { version = "1.0", default-features = false, optional = true }
+schemars = { version = "0.8.0", optional = true }
+
 [dev-dependencies]
 serde_test = "1.0"
 serde_json = "1.0"
 jsonschema-valid = "0.4.0"
-
-[dependencies]
-
-[dependencies.schemars]
-version = "0.8.0"
-optional = true
-
-[dependencies.serde]
-version = "1.0"
-optional = true
-default-features = false
 
 [target.wasm32-unknown-unknown.dev-dependencies]
 wasm-bindgen-test = "0.3"


### PR DESCRIPTION
The `[dependency.<crate>]` format is not common and is unclear IMO.