### PR TITLE
Repr(C) for hash types

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -29,6 +29,7 @@ use Error;
 /// Output of the Bitcoin HASH160 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_20"))]
     [u8; 20]

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -31,6 +31,7 @@ use Error;
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(transparent))]
+#[repr(transparent)]
 pub struct Hmac<T: HashTrait>(T);
 
 impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ macro_rules! hash_newtype {
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta, $reverse:expr) => {
         #[$docs]
         #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+        #[repr(transparent)]
         pub struct $newtype($hash);
 
         hex_fmt_impl!(Debug, $newtype);

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -77,6 +77,7 @@ impl EngineTrait for HashEngine {
 /// Output of the RIPEMD160 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_20"))]
     [u8; 20]

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -72,6 +72,7 @@ impl EngineTrait for HashEngine {
 /// Output of the SHA1 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_20"))]
     [u8; 20]

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -73,6 +73,7 @@ impl EngineTrait for HashEngine {
 /// Output of the SHA256 hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_32"))]
     [u8; 32]

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -23,6 +23,7 @@ use Error;
 /// Output of the SHA256d hash function
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_32"))]
     [u8; 32]

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -31,6 +31,7 @@ pub trait Tag {
 
 /// Output of the SHA256t hash function.
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash<T: Tag>(
     #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_32"))]
     [u8; 32],

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -79,6 +79,7 @@ impl EngineTrait for HashEngine {
 
 /// Output of the SHA256 hash function
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_64"))]
     [u8; 64]

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -197,6 +197,7 @@ impl EngineTrait for HashEngine {
 /// Output of the SipHash24 hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[repr(transparent)]
 pub struct Hash(
     #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_8"))]
     [u8; 8]


### PR DESCRIPTION
Required in order to make `OutPoint` in rust-bitcoin being `repr(C)`