### PR TITLE
Use cfg(fuzzing) instead of a fuzztarget feature and don't allow 0-hashes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ default = [ "std" ]
 std = []
 serde-std = ["serde/std"]
 unstable = []  # for benchmarking
-fuzztarget = [] # used by other rust-bitcoin projects to make hashes almost-noops, DON'T USE THIS
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -49,7 +49,7 @@ impl Default for HashEngine {
 impl EngineTrait for HashEngine {
     type MidState = [u8; 20];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
         for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
@@ -58,7 +58,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
         ret.copy_from_slice(&self.buffer[..20]);
@@ -97,7 +97,7 @@ impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn from_engine(mut e: HashEngine) -> Hash {
         // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
         let data_len = e.length as u64;
@@ -117,7 +117,7 @@ impl HashTrait for Hash {
         Hash(e.midstate())
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn from_engine(e: HashEngine) -> Hash {
         let mut res = e.midstate();
         res[0] ^= (e.length & 0xff) as u8;

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -44,7 +44,7 @@ impl Default for HashEngine {
 impl EngineTrait for HashEngine {
     type MidState = [u8; 20];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
         for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
@@ -53,7 +53,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
         ret.copy_from_slice(&self.buffer[..20]);

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -115,7 +115,13 @@ impl HashTrait for Hash {
 
     #[cfg(fuzzing)]
     fn from_engine(e: HashEngine) -> Hash {
-        Hash(e.midstate().into_inner())
+        let mut hash = e.midstate().into_inner();
+        if hash == [0; 32] {
+            // Assume sha256 is secure and never generate 0-hashes (which represent invalid
+            // secp256k1 secret keys, causing downstream application breakage).
+            hash[0] = 1;
+        }
+        Hash(hash)
     }
 
     const LEN: usize = 32;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -45,7 +45,7 @@ impl Default for HashEngine {
 impl EngineTrait for HashEngine {
     type MidState = Midstate;
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn midstate(&self) -> Midstate {
         let mut ret = [0; 32];
         for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
@@ -54,7 +54,7 @@ impl EngineTrait for HashEngine {
         Midstate(ret)
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn midstate(&self) -> Midstate {
         let mut ret = [0; 32];
         ret.copy_from_slice(&self.buffer[..32]);
@@ -93,7 +93,7 @@ impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 32];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn from_engine(mut e: HashEngine) -> Hash {
         // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
         let data_len = e.length as u64;
@@ -113,7 +113,7 @@ impl HashTrait for Hash {
         Hash(e.midstate().into_inner())
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn from_engine(e: HashEngine) -> Hash {
         Hash(e.midstate().into_inner())
     }

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -52,7 +52,7 @@ impl Default for HashEngine {
 impl EngineTrait for HashEngine {
     type MidState = [u8; 64];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn midstate(&self) -> [u8; 64] {
         let mut ret = [0; 64];
         for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(8)) {
@@ -61,7 +61,7 @@ impl EngineTrait for HashEngine {
         ret
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn midstate(&self) -> [u8; 64] {
         let mut ret = [0; 64];
         ret.copy_from_slice(&self.buffer[..64]);
@@ -141,7 +141,7 @@ impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 64];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn from_engine(mut e: HashEngine) -> Hash {
         // pad buffer with a single 1-bit then all 0s, until there are exactly 16 bytes remaining
         let data_len = e.length as u64;
@@ -162,7 +162,7 @@ impl HashTrait for Hash {
         Hash(e.midstate())
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn from_engine(e: HashEngine) -> Hash {
         let mut hash = e.midstate();
         hash[0] ^= 0xff; // Make this distinct from SHA-256

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -260,12 +260,12 @@ impl HashTrait for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 8];
 
-    #[cfg(not(feature = "fuzztarget"))]
+    #[cfg(not(fuzzing))]
     fn from_engine(e: HashEngine) -> Hash {
         Hash::from_u64(Hash::from_engine_to_u64(e))
     }
 
-    #[cfg(feature = "fuzztarget")]
+    #[cfg(fuzzing)]
     fn from_engine(e: HashEngine) -> Hash {
         let state = e.midstate();
         Hash::from_u64(state.v0 ^ state.v1 ^ state.v2 ^ state.v3)

--- a/src/util.rs
+++ b/src/util.rs
@@ -117,7 +117,7 @@ macro_rules! borrow_slice_impl(
 
 macro_rules! engine_input_impl(
     () => (
-        #[cfg(not(feature = "fuzztarget"))]
+        #[cfg(not(fuzzing))]
         fn input(&mut self, mut inp: &[u8]) {
             while !inp.is_empty() {
                 let buf_idx = self.length % <Self as EngineTrait>::BLOCK_SIZE;
@@ -134,7 +134,7 @@ macro_rules! engine_input_impl(
             }
         }
 
-        #[cfg(feature = "fuzztarget")]
+        #[cfg(fuzzing)]
         fn input(&mut self, inp: &[u8]) {
             for c in inp {
                 self.buffer[0] ^= *c;


### PR DESCRIPTION
https://github.com/rust-bitcoin/rust-secp256k1/pull/264 starts enforcing that 32 bytes of 0s is an invalid private key in fuzzing, which breaks downstream applications which don't bother to check for the sha256-is-broken case. https://github.com/rust-bitcoin/rust-secp256k1/pull/282 keeps that behavior, so best to no longer return 0 hashes from sha256 at all. We also update to use the new fuzzing cfg which is nicer anyway.