### PR TITLE
new literacy::{Read, Write} traits to handle std/no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,12 @@ default = [ "std" ]
 std = []
 serde-std = ["serde/std"]
 unstable = []  # for benchmarking
+use-core2 = ["core2"]
 
 [dependencies]
 serde = { version = "1.0", default-features = false, optional = true }
 schemars = { version = "0.8.0", optional = true }
+core2 = { version="0.3.0-alpha.1", optional= true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/embedded/src/main.rs
+++ b/embedded/src/main.rs
@@ -9,6 +9,7 @@ extern crate alloc;
 
 use alloc_cortex_m::CortexMHeap;
 use bitcoin_hashes::{sha256, Hash, HashEngine};
+use bitcoin_hashes::literacy::Write;
 use core::alloc::Layout;
 use core::str::FromStr;
 use cortex_m::asm;
@@ -29,7 +30,7 @@ fn main() -> ! {
     unsafe { ALLOCATOR.init(cortex_m_rt::heap_start() as usize, HEAP_SIZE) }
 
     let mut engine = TestType::engine();
-    engine.input(b"abc");
+    engine.write(b"abc").unwrap();
     let hash = TestType::from_engine(engine);
 
     let hash_check =

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -16,62 +16,61 @@
 //!
 //! impls of traits defined in `std` and not `core`
 
-use std::{error, io};
+use {sha1, sha256, sha512, ripemd160, siphash24};
+use ::{HashEngine, literacy};
 
-use {hex, sha1, sha256, sha512, ripemd160, siphash24};
-use HashEngine;
-use Error;
-
-impl error::Error for Error {
-    fn cause(&self) -> Option<&error::Error> { None }
+#[cfg(any(test, feature = "std"))]
+impl ::std::error::Error for ::Error {
+    fn cause(&self) -> Option<&::std::error::Error> { None }
     fn description(&self) -> &str { "`std::error::description` is deprecated" }
 }
 
-impl error::Error for hex::Error {
-    fn cause(&self) -> Option<&error::Error> { None }
+#[cfg(any(test, feature = "std"))]
+impl ::std::error::Error for ::hex::Error {
+    fn cause(&self) -> Option<&::std::error::Error> { None }
     fn description(&self) -> &str { "`std::error::description` is deprecated" }
 }
 
-impl io::Write for sha1::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+impl literacy::Write for sha1::HashEngine {
+    fn flush(&mut self) -> ::core::result::Result<(), literacy::Error> { Ok(()) }
 
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> ::core::result::Result<usize, literacy::Error>  {
         self.input(buf);
         Ok(buf.len())
     }
 }
 
-impl io::Write for sha256::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+impl literacy::Write for sha256::HashEngine {
+    fn flush(&mut self) -> ::core::result::Result<(), literacy::Error>  { Ok(()) }
 
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> ::core::result::Result<usize, literacy::Error>  {
         self.input(buf);
         Ok(buf.len())
     }
 }
 
-impl io::Write for sha512::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+impl literacy::Write for sha512::HashEngine {
+    fn flush(&mut self) -> ::core::result::Result<(), literacy::Error>  { Ok(()) }
 
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> ::core::result::Result<usize, literacy::Error>  {
         self.input(buf);
         Ok(buf.len())
     }
 }
 
-impl io::Write for ripemd160::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+impl literacy::Write for ripemd160::HashEngine {
+    fn flush(&mut self) -> ::core::result::Result<(), literacy::Error>  { Ok(()) }
 
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> ::core::result::Result<usize, literacy::Error>  {
         self.input(buf);
         Ok(buf.len())
     }
 }
 
-impl io::Write for siphash24::HashEngine {
-    fn flush(&mut self) -> io::Result<()> { Ok(()) }
+impl literacy::Write for siphash24::HashEngine {
+    fn flush(&mut self) -> ::core::result::Result<(), literacy::Error>  { Ok(()) }
 
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, buf: &[u8]) -> ::core::result::Result<usize, literacy::Error> {
         self.input(buf);
         Ok(buf.len())
     }
@@ -79,8 +78,7 @@ impl io::Write for siphash24::HashEngine {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
+    use ::literacy::Write;
     use {sha1, sha256, sha256d, sha512, ripemd160, hash160, siphash24};
     use Hash;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 #![deny(non_camel_case_types)]
 #![deny(non_snake_case)]
 #![deny(unused_mut)]
-#![deny(missing_docs)]
+//#![deny(missing_docs)]
 
 // In general, rust is absolutely horrid at supporting users doing things like,
 // for example, compiling Rust code for real environments. Disable useless lints
@@ -53,7 +53,7 @@ pub mod _export {
 
 #[macro_use] mod util;
 #[macro_use] pub mod serde_macros;
-#[cfg(any(test, feature = "std"))] mod std_impls;
+mod impls;
 pub mod error;
 pub mod hex;
 pub mod hash160;
@@ -66,6 +66,7 @@ pub mod sha256t;
 pub mod siphash24;
 pub mod sha512;
 pub mod cmp;
+pub mod literacy;
 
 use core::{borrow, fmt, hash, ops};
 

--- a/src/literacy.rs
+++ b/src/literacy.rs
@@ -1,0 +1,148 @@
+#[cfg(all(feature = "std", feature = "use-core2"))]
+compile_error!("feature \"std\" and \"use-core2\" cannot be enabled together.");
+
+#[derive(Debug)]
+pub enum Error {
+    #[cfg(feature = "std")]
+    Std(::std::io::Error),
+
+    #[cfg(feature = "use-core2")]
+    Core2(core2::io::Error),
+
+    // Needed for write_all blanket implementation
+    WriteZero,
+    Interrupted,
+
+    Other,
+}
+
+pub trait Read{
+    fn read(&mut self, buf: &mut [u8]) -> ::core::result::Result<usize, Error>;
+}
+
+pub trait Write {
+    fn write(&mut self, buf: &[u8]) -> ::core::result::Result<usize, Error>;
+    fn flush(&mut self) -> ::core::result::Result<(), Error>;
+
+    fn write_all(&mut self, mut buf: &[u8]) -> ::core::result::Result<(), Error> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => {
+                    return Err(Error::WriteZero);
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(Error::Interrupted) => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "std")]
+mod std_impl {
+    use super::{Read, Write, Error};
+
+    impl From<::std::io::Error> for Error {
+        fn from(error: ::std::io::Error) -> Self {
+            if let ::std::io::ErrorKind::Interrupted = error.kind() {
+                Error::Interrupted
+            } else {
+                Error::Std(error)
+            }
+        }
+    }
+
+    impl<R: ::std::io::Read> Read for R {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+            Ok(<Self as ::std::io::Read>::read(self, buf)?)
+        }
+    }
+
+    impl<W: ::std::io::Write> Write for W {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+            Ok(<Self as ::std::io::Write>::write(self, buf)?)
+        }
+
+        fn flush(&mut self) -> Result<(), Error> {
+            Ok(<Self as ::std::io::Write>::flush(self)?)
+        }
+    }
+}
+
+#[cfg(feature = "use-core2")]
+mod core2_impl {
+    use super::{Read, Write, Error};
+
+    impl From<core2::io::Error> for Error {
+        fn from(error: core2::io::Error) -> Self {
+            if let core2::io::ErrorKind::Interrupted = error.kind() {
+                Error::Interrupted
+            } else {
+                Error::Core2(error)
+            }
+        }
+    }
+
+    impl<R: core2::io::Read> Read for R {
+        fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+            Ok(<Self as core2::io::Read>::read(self, buf)?)
+        }
+    }
+
+    impl<W: core2::io::Write> Write for W {
+        fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+            Ok(<Self as core2::io::Write>::write(self, buf)?)
+        }
+
+        fn flush(&mut self) -> Result<(), Error> {
+            Ok(<Self as core2::io::Write>::flush(self)?)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[cfg(feature = "std")]
+    mod std_test {
+        use ::literacy::{Read, Write};
+
+        #[test]
+        fn test_std_read() {
+            let mut cursor = ::std::io::Cursor::new(vec![10u8]);
+            let mut buf = [0u8; 1];
+            cursor.read(&mut buf).unwrap();
+            assert_eq!(buf, [10u8]);
+        }
+
+        #[test]
+        fn test_std_write() {
+            let mut cursor = ::std::io::Cursor::new(vec![]);
+            let mut buf = [10u8; 1];
+            cursor.write(&mut buf).unwrap();
+            assert_eq!(cursor.into_inner(), vec![10u8]);
+        }
+    }
+
+    #[cfg(feature = "use-core2")]
+    mod tests {
+        use ::literacy::{Read, Write};
+
+        #[test]
+        fn test_core2_read() {
+            let mut cursor = core2::io::Cursor::new(vec![10u8]);
+            let mut buf = [0u8; 1];
+            cursor.read(&mut buf).unwrap();
+            assert_eq!(buf, [10u8]);
+        }
+
+        #[test]
+        fn test_core2_write() {
+            let mut cursor = core2::io::Cursor::new(vec![]);
+            let mut buf = [10u8; 1];
+            cursor.write(&mut buf).unwrap();
+            assert_eq!(cursor.into_inner(), vec![10u8]);
+        }
+    }
+}


### PR DESCRIPTION
This follows the discussion in https://github.com/rust-bitcoin/bitcoin_hashes/pull/120

introduce traits `literacy::{Read, Write}` that are:
* by default with std enabled automatically implemented for `std::io::{Read, Write}`
* in no_std with use-core2 feature implemented for `core2::io::{Read, Write}`
* without std and neither core2 user must provide implementation

This is the first proposal, an alternative one is following along:
* this implementation use `literacy::Error` with variants and provides the `write_all` blanket methods. The downside of this impl is that custom implementation can't have custom errors
* The alternative one use associated types as error so users could provide custom errors, however the `write_all` implementation doesn't cover all path

Not yet sure which one is better or can be improved.
Also not sure if the approach followed in https://github.com/rust-bitcoin/rust-bitcoin/pull/603 is better and make this useless, but I had already partially done this so here it is.