### PR TITLE
Implements Read on HexIterator

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -20,6 +20,11 @@ use alloc::{string::String, vec::Vec};
 #[cfg(feature = "alloc")]
 use alloc::format;
 
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(all(not(feature = "std"), feature = "core2"))]
+use core2::io;
+
 use core::{fmt, str};
 use Hash;
 
@@ -132,6 +137,23 @@ impl<'a> Iterator for HexIterator<'a> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (min, max) = self.iter.size_hint();
         (min / 2, max.map(|x| x /2))
+    }
+}
+
+#[cfg(any(feature = "std", feature = "core2"))]
+impl<'a> io::Read for HexIterator<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0usize;
+        for dst in buf {
+            match self.next() {
+                Some(Ok(src)) => {
+                    *dst = src;
+                    bytes_read += 1;
+                },
+                _ => break,
+            }
+        }
+        Ok(bytes_read)
     }
 }
 


### PR DESCRIPTION
This would allow deserializing objects without allocating the intermediate byte vector like:

```
let tx = Transaction::consensus_decode(HexIterator::new("....").unwrap()).unwrap()
```

Especially useful for libraries like rust_bitcoincore_rpc in places like this https://github.com/rust-bitcoin/rust-bitcoincore-rpc/blob/54a427f2e45b0b8712d44a6995f6a03ad5f961f8/client/src/client.rs#L322-L326


CI is failing on my repo I think for an unrelated reason I am not fully grasping at the moment, @JeremyRubin could you have a look?
