### PR TITLE
Enable edition 2018

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.29.0
+          - 1.41.1
           - beta
           - stable
     steps:
@@ -73,14 +73,11 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Pin cc if rust 1.29
-        if: matrix.rust == '1.29.0'
-        run: cargo generate-lockfile && cargo update -p serde_json --precise "1.0.39"
       - name: Running cargo
         env:
           DO_FEATURE_MATRIX: true
-          DO_SCHEMARS_TESTS: ${{matrix.rust != '1.29.0'}}
-          DO_ALLOC_TESTS: ${{matrix.rust != '1.29.0'}}
+          DO_SCHEMARS_TESTS: true
+          DO_ALLOC_TESTS: true
         run: ./contrib/test.sh
 
   Embedded:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,4 @@
+
 on: [push, pull_request]
 
 name: Continuous integration
@@ -11,7 +12,7 @@ jobs:
         rust:
           - nightly
     steps:
-      - name: Checkout Crate 
+      - name: Checkout Crate
         uses: actions/checkout@v2
       - name: Checkout Toolchain
         uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/rust-bitcoin/bitcoin_hashes/"
 documentation = "https://docs.rs/bitcoin_hashes/"
 keywords = [ "crypto", "bitcoin", "hash", "digest" ]
 readme = "README.md"
+edition = "2018"
 
 [lib]
 name = "bitcoin_hashes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitcoin_hashes"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Andrew Poelstra <apoelstra@wpsoftware.net>"]
 license = "CC0-1.0"
 description = "Hash functions used by rust-bitcoin which support rustc 1.29.0"

--- a/README.md
+++ b/README.md
@@ -11,14 +11,7 @@ since these are needed to display hashes anway.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This library should always compile with any combination of features on **Rust 1.29**.
-However, due to some dependencies breaking their MSRV in patch releases, you may
-need to pin these deps explicitly, e.g. with the following commands
-
-```
-cargo generate-lockfile
-cargo update -p serde_json --precise "1.0.39"
-```
+This library should always compile with any combination of features on **Rust 1.41.1**.
 
 ## Contributions
 

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -83,10 +83,8 @@ fn eq_test() {
 mod benches {
     use test::Bencher;
 
-    use sha256;
-    use sha512;
-    use Hash;
-    use cmp::fixed_time_eq;
+    use crate::{Hash, sha256, sha512};
+    use crate::cmp::fixed_time_eq;
 
     #[bench]
     fn bench_32b_constant_time_cmp_ne(bh: &mut Bencher) {

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -24,10 +24,7 @@ use core::str;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use sha256;
-use ripemd160;
-use Hash as HashTrait;
-use Error;
+use crate::{Error, hex, ripemd160, sha256};
 
 /// Output of the Bitcoin HASH160 hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
@@ -54,13 +51,13 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
 }
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = sha256::HashEngine;
     type Inner = [u8; 20];
 
@@ -107,8 +104,8 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use {hash160, Hash, HashEngine};
-        use hex::{FromHex, ToHex};
+        use crate::{hash160, Hash, HashEngine};
+        use crate::hex::{FromHex, ToHex};
 
         #[derive(Clone)]
         #[cfg(any(feature = "std", feature = "alloc"))]
@@ -162,7 +159,7 @@ mod tests {
     #[test]
     fn ripemd_serde() {
         use serde_test::{Configure, Token, assert_tokens};
-        use {hash160, Hash};
+        use crate::{hash160, Hash};
 
         static HASH_BYTES: [u8; 20] = [
             0x13, 0x20, 0x72, 0xdf,
@@ -182,9 +179,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use hash160;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, hash160};
 
     #[bench]
     pub fn hash160_10(bh: &mut Bencher) {

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -16,9 +16,9 @@
 //!
 
 #[cfg(any(feature = "std", feature = "alloc"))]
-use alloc::{string::String, vec::Vec};
+use crate::alloc::{string::String, vec::Vec};
 #[cfg(feature = "alloc")]
-use alloc::format;
+use crate::alloc::format;
 
 #[cfg(feature = "std")]
 use std::io;
@@ -26,7 +26,7 @@ use std::io;
 use core2::io;
 
 use core::{fmt, str};
-use Hash;
+use crate::Hash;
 
 /// Hex decoding error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -24,18 +24,16 @@ use core::{borrow, fmt, ops, str};
 #[cfg(feature = "serde")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
-use Error;
+use crate::{Error, Hash, HashEngine};
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(transparent))]
 #[repr(transparent)]
-pub struct Hmac<T: HashTrait>(T);
+pub struct Hmac<T: Hash>(T);
 
-impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {
+impl<T: Hash + str::FromStr> str::FromStr for Hmac<T> {
     type Err = <T as str::FromStr>::Err;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Hmac(str::FromStr::from_str(s)?))
@@ -43,27 +41,27 @@ impl<T: HashTrait + str::FromStr> str::FromStr for Hmac<T> {
 }
 
 /// Pair of underlying hash midstates which represent the current state of an `HmacEngine`.
-pub struct HmacMidState<T: HashTrait> {
+pub struct HmacMidState<T: Hash> {
     /// Midstate of the inner hash engine
-    pub inner: <T::Engine as EngineTrait>::MidState,
+    pub inner: <T::Engine as HashEngine>::MidState,
     /// Midstate of the outer hash engine
-    pub outer: <T::Engine as EngineTrait>::MidState,
+    pub outer: <T::Engine as HashEngine>::MidState,
 }
 
 /// Pair of underyling hash engines, used for the inner and outer hash of HMAC.
 #[derive(Clone)]
-pub struct HmacEngine<T: HashTrait> {
+pub struct HmacEngine<T: Hash> {
     iengine: T::Engine,
     oengine: T::Engine,
 }
 
-impl<T: HashTrait> Default for HmacEngine<T> {
+impl<T: Hash> Default for HmacEngine<T> {
     fn default() -> Self {
         HmacEngine::new(&[])
     }
 }
 
-impl<T: HashTrait> HmacEngine<T> {
+impl<T: Hash> HmacEngine<T> {
     /// Constructs a new keyed HMAC from `key`.
     ///
     /// We only support underlying hashes whose block sizes are ≤ 128 bytes.
@@ -77,12 +75,12 @@ impl<T: HashTrait> HmacEngine<T> {
         let mut ipad = [0x36u8; 128];
         let mut opad = [0x5cu8; 128];
         let mut ret = HmacEngine {
-            iengine: <T as HashTrait>::engine(),
-            oengine: <T as HashTrait>::engine(),
+            iengine: <T as Hash>::engine(),
+            oengine: <T as Hash>::engine(),
         };
 
         if key.len() > T::Engine::BLOCK_SIZE {
-            let hash = <T as HashTrait>::hash(key);
+            let hash = <T as Hash>::hash(key);
             for (b_i, b_h) in ipad.iter_mut().zip(&hash[..]) {
                 *b_i ^= *b_h;
             }
@@ -98,8 +96,8 @@ impl<T: HashTrait> HmacEngine<T> {
             }
         };
 
-        EngineTrait::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
-        EngineTrait::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
+        HashEngine::input(&mut ret.iengine, &ipad[..T::Engine::BLOCK_SIZE]);
+        HashEngine::input(&mut ret.oengine, &opad[..T::Engine::BLOCK_SIZE]);
         ret
     }
 
@@ -112,7 +110,7 @@ impl<T: HashTrait> HmacEngine<T> {
     }
 }
 
-impl<T: HashTrait> EngineTrait for HmacEngine<T> {
+impl<T: Hash> HashEngine for HmacEngine<T> {
     type MidState = HmacMidState<T>;
 
     fn midstate(&self) -> Self::MidState {
@@ -133,66 +131,66 @@ impl<T: HashTrait> EngineTrait for HmacEngine<T> {
     }
 }
 
-impl<T: HashTrait> fmt::Debug for Hmac<T> {
+impl<T: Hash> fmt::Debug for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
     }
 }
 
-impl<T: HashTrait> fmt::Display for Hmac<T> {
+impl<T: Hash> fmt::Display for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }
 
-impl<T: HashTrait> fmt::LowerHex for Hmac<T> {
+impl<T: Hash> fmt::LowerHex for Hmac<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
-impl<T: HashTrait> ops::Index<usize> for Hmac<T> {
+impl<T: Hash> ops::Index<usize> for Hmac<T> {
     type Output = u8;
     fn index(&self, index: usize) -> &u8 {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::Range<usize>> for Hmac<T> {
+impl<T: Hash> ops::Index<ops::Range<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::Range<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::RangeFrom<usize>> for Hmac<T> {
+impl<T: Hash> ops::Index<ops::RangeFrom<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFrom<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::RangeTo<usize>> for Hmac<T> {
+impl<T: Hash> ops::Index<ops::RangeTo<usize>> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeTo<usize>) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> ops::Index<ops::RangeFull> for Hmac<T> {
+impl<T: Hash> ops::Index<ops::RangeFull> for Hmac<T> {
     type Output = [u8];
     fn index(&self, index: ops::RangeFull) -> &[u8] {
         &self.0[index]
     }
 }
 
-impl<T: HashTrait> borrow::Borrow<[u8]> for Hmac<T> {
+impl<T: Hash> borrow::Borrow<[u8]> for Hmac<T> {
     fn borrow(&self) -> &[u8] {
         &self[..]
     }
 }
 
-impl<T: HashTrait> HashTrait for Hmac<T> {
+impl<T: Hash> Hash for Hmac<T> {
     type Engine = HmacEngine<T>;
     type Inner = T::Inner;
 
@@ -224,7 +222,7 @@ impl<T: HashTrait> HashTrait for Hmac<T> {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
+impl<T: Hash + Serialize> Serialize for Hmac<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(&self.0, s)
     }
@@ -232,7 +230,7 @@ impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
 
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
-impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
+impl<'de, T: Hash + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Hmac<T>, D::Error> {
         let inner = Deserialize::deserialize(d)?;
         Ok(Hmac(inner))
@@ -244,7 +242,7 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use {sha256, HashEngine, HmacEngine, Hash, Hmac};
+        use crate::{sha256, HashEngine, HmacEngine, Hash, Hmac};
 
         #[derive(Clone)]
         struct Test {
@@ -370,7 +368,7 @@ mod tests {
     #[test]
     fn hmac_sha512_serde() {
         use serde_test::{Configure, Token, assert_tokens};
-        use {sha512, Hash, Hmac};
+        use crate::{sha512, Hash, Hmac};
 
         static HASH_BYTES: [u8; 64] = [
             0x8b, 0x41, 0xe1, 0xb7, 0x8a, 0xd1, 0x15, 0x21,
@@ -399,8 +397,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use sha256;
-    use {Hmac, Hash, HashEngine};
+    use crate::{Hmac, Hash, HashEngine, sha256};
 
     #[bench]
     pub fn hmac_sha256_10(bh: &mut Bencher) {

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -23,9 +23,7 @@ use std::{error, io};
 #[cfg(not(feature = "std"))]
 use core2::{error, io};
 
-use {hex, sha1, sha256, sha512, ripemd160, siphash24, hmac};
-use HashEngine;
-use Error;
+use crate::{Error, HashEngine, hex, sha1, sha256, sha512, ripemd160, siphash24, hmac};
 
 impl error::Error for Error {
     #[cfg(feature = "std")]
@@ -86,7 +84,7 @@ impl io::Write for siphash24::HashEngine {
     }
 }
 
-impl<T: ::Hash> io::Write for hmac::HmacEngine<T> {
+impl<T: crate::Hash> io::Write for hmac::HmacEngine<T> {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
@@ -99,8 +97,7 @@ impl<T: ::Hash> io::Write for hmac::HmacEngine<T> {
 mod tests {
     use super::io::Write;
 
-    use {sha1, sha256, sha256d, sha512, ripemd160, hash160, siphash24, hmac};
-    use Hash;
+    use crate::{Hash, sha1, sha256, sha256d, sha512, ripemd160, hash160, siphash24, hmac};
 
     macro_rules! write_test {
         ($mod:ident, $exp_empty:expr, $exp_256:expr, $exp_64k:expr,) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,10 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
 
 #[cfg(test)]
 mod tests {
-    use Hash;
-    hash_newtype!(TestNewtype, ::sha256d::Hash, 32, doc="A test newtype");
-    hash_newtype!(TestNewtype2, ::sha256d::Hash, 32, doc="A test newtype");
+    use crate::{Hash, sha256d};
+
+    hash_newtype!(TestNewtype, sha256d::Hash, 32, doc="A test newtype");
+    hash_newtype!(TestNewtype2, sha256d::Hash, 32, doc="A test newtype");
 
     #[test]
     fn convert_newtypes() {
@@ -163,7 +164,7 @@ mod tests {
         let h2: TestNewtype2 = h1.as_hash().into();
         assert_eq!(&h1[..], &h2[..]);
 
-        let h = ::sha256d::Hash::hash(&[]);
+        let h = sha256d::Hash::hash(&[]);
         let h2: TestNewtype = h.to_string().parse().unwrap();
         assert_eq!(h2.as_hash(), h);
     }

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -24,10 +24,7 @@ use core::{cmp, str};
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
-use Error;
-use util;
+use crate::{Error, HashEngine as _, hex, util};
 
 const BLOCK_SIZE: usize = 64;
 
@@ -49,7 +46,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl crate::HashEngine for HashEngine {
     type MidState = [u8; 20];
 
     #[cfg(not(fuzzing))]
@@ -102,13 +99,13 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
 }
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
 
@@ -462,9 +459,8 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use ripemd160;
-        use {Hash, HashEngine};
-        use hex::{FromHex, ToHex};
+        use crate::{Hash, HashEngine, ripemd160};
+        use crate::hex::{FromHex, ToHex};
 
         #[derive(Clone)]
         struct Test {
@@ -545,7 +541,7 @@ mod tests {
     #[test]
     fn ripemd_serde() {
         use serde_test::{Configure, Token, assert_tokens};
-        use {ripemd160, Hash};
+        use crate::{ripemd160, Hash};
 
         static HASH_BYTES: [u8; 20] = [
             0x13, 0x20, 0x72, 0xdf,
@@ -565,9 +561,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use ripemd160;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, ripemd160};
 
     #[bench]
     pub fn ripemd160_10(bh: &mut Bencher) {

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -19,7 +19,7 @@
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde_details {
-    use Error;
+    use crate::Error;
 
     use core::marker::PhantomData;
     use core::{fmt, ops, str};
@@ -130,6 +130,8 @@ macro_rules! serde_impl(
         impl $crate::serde_macros::serde_details::SerdeHash for $t {
             const N : usize = $len;
             fn from_slice_delegated(sl: &[u8]) -> Result<Self, $crate::Error> {
+                #[allow(unused_imports)]
+                use $crate::Hash as _;
                 $t::from_slice(sl)
             }
         }

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -19,10 +19,7 @@ use core::{cmp, str};
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
-use Error;
-use util;
+use crate::{Error, HashEngine as _, hex, util};
 
 const BLOCK_SIZE: usize = 64;
 
@@ -44,7 +41,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl crate::HashEngine for HashEngine {
     type MidState = [u8; 20];
 
     #[cfg(not(fuzzing))]
@@ -97,13 +94,13 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
 }
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 20];
 
@@ -200,8 +197,8 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use {sha1, Hash, HashEngine};
-        use hex::{FromHex, ToHex};
+        use crate::{sha1, Hash, HashEngine};
+        use crate::hex::{FromHex, ToHex};
 
         #[derive(Clone)]
         struct Test {
@@ -270,7 +267,7 @@ mod tests {
     #[test]
     fn sha1_serde() {
         use serde_test::{Configure, Token, assert_tokens};
-        use {sha1, Hash};
+        use crate::{sha1, Hash};
 
         static HASH_BYTES: [u8; 20] = [
             0x13, 0x20, 0x72, 0xdf,
@@ -290,9 +287,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use sha1;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, sha1};
 
     #[bench]
     pub fn sha1_10(bh: &mut Bencher) {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -19,11 +19,7 @@ use core::{cmp, str};
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use hex;
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
-use Error;
-use util;
+use crate::{Error, HashEngine as _, hex, util};
 
 const BLOCK_SIZE: usize = 64;
 
@@ -45,7 +41,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl crate::HashEngine for HashEngine {
     type MidState = Midstate;
 
     #[cfg(not(fuzzing))]
@@ -83,9 +79,9 @@ pub struct Hash(
 );
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
@@ -104,7 +100,7 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 32];
 
@@ -184,9 +180,9 @@ impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
 }
 
 impl str::FromStr for Midstate {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
@@ -372,13 +368,12 @@ impl HashEngine {
 
 #[cfg(test)]
 mod tests {
-    use sha256;
-    use {Hash, HashEngine};
+    use crate::{Hash, HashEngine, sha256};
 
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use hex::{FromHex, ToHex};
+        use crate::hex::{FromHex, ToHex};
 
         #[derive(Clone)]
         struct Test {
@@ -549,9 +544,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use sha256;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, sha256};
 
     #[bench]
     pub fn sha256_10(bh: &mut Bencher) {

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -19,9 +19,7 @@ use core::str;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use sha256;
-use Hash as HashTrait;
-use Error;
+use crate::{Error, hex, sha256};
 
 /// Output of the SHA256d hash function.
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
@@ -48,13 +46,13 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
 }
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = sha256::HashEngine;
     type Inner = [u8; 32];
 
@@ -103,8 +101,8 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use {sha256d, Hash, HashEngine};
-        use hex::{FromHex, ToHex};
+        use crate::{sha256d, Hash, HashEngine};
+        use crate::hex::{FromHex, ToHex};
 
         #[derive(Clone)]
         struct Test {
@@ -149,7 +147,7 @@ mod tests {
     #[test]
     fn sha256_serde() {
         use serde_test::{Configure, Token, assert_tokens};
-        use {sha256d, Hash};
+        use crate::{sha256d, Hash};
 
         static HASH_BYTES: [u8; 32] = [
             0xef, 0x53, 0x7f, 0x25, 0xc8, 0x95, 0xbf, 0xa7,
@@ -168,9 +166,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use sha256d;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, sha256d};
 
     #[bench]
     pub fn sha256d_10(bh: &mut Bencher) {

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -21,10 +21,8 @@ use core::marker::PhantomData;
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use sha256;
-use Hash as HashTrait;
-#[allow(unused)]
-use Error;
+use crate::{Error, hex, sha256};
+#[cfg(feature="serde")] use crate::Hash as _;
 
 /// Trait representing a tag that can be used as a context for SHA256t hashes.
 pub trait Tag {
@@ -76,9 +74,9 @@ impl<T: Tag> ::core::hash::Hash for Hash<T> {
 }
 
 impl<T: Tag> str::FromStr for Hash<T> {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
@@ -96,7 +94,7 @@ impl<I: SliceIndex<[u8]>, T: Tag> Index<I> for Hash<T> {
     }
 }
 
-impl<T: Tag> HashTrait for Hash<T> {
+impl<T: Tag> crate::Hash for Hash<T> {
     type Engine = sha256::HashEngine;
     type Inner = [u8; 32];
 
@@ -252,9 +250,11 @@ impl<'de, T: Tag> ::serde::Deserialize<'de> for Hash<T> {
 
 #[cfg(test)]
 mod tests {
-    use ::{Hash, sha256, sha256t};
+    use crate::{sha256, sha256t};
     #[cfg(any(feature = "std", feature = "alloc"))]
-    use ::hex::ToHex;
+    use crate::hex::ToHex;
+    #[cfg(any(feature = "std", feature = "alloc"))]
+    use crate::Hash;
 
     const TEST_MIDSTATE: [u8; 32] = [
        156, 224, 228, 230, 124, 17, 108, 57, 56, 179, 202, 242, 195, 15, 80, 137, 211, 243,

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -24,10 +24,7 @@ use core::{cmp, hash, str};
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use HashEngine as EngineTrait;
-use Hash as HashTrait;
-use Error;
-use util;
+use crate::{Error, HashEngine as _, hex, util};
 
 const BLOCK_SIZE: usize = 128;
 
@@ -52,7 +49,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl crate::HashEngine for HashEngine {
     type MidState = [u8; 64];
 
     #[cfg(not(fuzzing))]
@@ -131,9 +128,9 @@ impl hash::Hash for Hash {
 }
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
@@ -152,7 +149,7 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 64];
 
@@ -351,8 +348,8 @@ mod tests {
     #[test]
     #[cfg(any(feature = "std", feature = "alloc"))]
     fn test() {
-        use {sha512, Hash, HashEngine};
-        use hex::{FromHex, ToHex};
+        use crate::{sha512, Hash, HashEngine};
+        use crate::hex::{FromHex, ToHex};
 
         #[derive(Clone)]
         struct Test {
@@ -429,7 +426,7 @@ mod tests {
     #[test]
     fn sha512_serde() {
         use serde_test::{Configure, Token, assert_tokens};
-        use {sha512, Hash};
+        use crate::{sha512, Hash};
 
         static HASH_BYTES: [u8; 64] = [
             0x8b, 0x41, 0xe1, 0xb7, 0x8a, 0xd1, 0x15, 0x21,
@@ -458,9 +455,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use sha512;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, sha512};
 
     #[bench]
     pub fn sha512_10(bh: &mut Bencher) {

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -24,10 +24,7 @@ use core::{cmp, mem, ptr, str};
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use Error;
-use Hash as HashTrait;
-use HashEngine as EngineTrait;
-use util;
+use crate::{Error, Hash as _, HashEngine as _, hex, util};
 
 macro_rules! compress {
     ($state:expr) => {{
@@ -142,7 +139,7 @@ impl Default for HashEngine {
     }
 }
 
-impl EngineTrait for HashEngine {
+impl crate::HashEngine for HashEngine {
     type MidState = State;
 
     fn midstate(&self) -> State {
@@ -222,9 +219,9 @@ impl<I: SliceIndex<[u8]>> Index<I> for Hash {
 }
 
 impl str::FromStr for Hash {
-    type Err = ::hex::Error;
+    type Err = hex::Error;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        ::hex::FromHex::from_hex(s)
+        hex::FromHex::from_hex(s)
     }
 }
 
@@ -271,7 +268,7 @@ impl Hash {
     }
 }
 
-impl HashTrait for Hash {
+impl crate::Hash for Hash {
     type Engine = HashEngine;
     type Inner = [u8; 8];
 
@@ -338,7 +335,6 @@ unsafe fn u8to64_le(buf: &[u8], start: usize, len: usize) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use Hash as HashTrait;
 
     #[test]
     fn test_siphash_2_4() {
@@ -431,9 +427,7 @@ mod tests {
 mod benches {
     use test::Bencher;
 
-    use siphash24;
-    use Hash;
-    use HashEngine;
+    use crate::{Hash, HashEngine, siphash24};
 
     #[bench]
     pub fn siphash24_1ki(bh: &mut Bencher) {

--- a/src/util.rs
+++ b/src/util.rs
@@ -31,15 +31,17 @@ macro_rules! hex_fmt_impl(
     ($imp:ident, $ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::$imp for $ty<$($gen),*> {
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
-                use $crate::hex::{format_hex, format_hex_reverse};
+                #[allow(unused_imports)]
+                use $crate::{Hash as _, HashEngine as _, hex};
+
                 if $ty::<$($gen),*>::DISPLAY_BACKWARD {
-                    format_hex_reverse(&self.0, f)
+                    hex::format_hex_reverse(&self.0, f)
                 } else {
-                    format_hex(&self.0, f)
+                    hex::format_hex(&self.0, f)
                 }
             }
         }
-    )
+    );
 );
 
 /// Adds slicing traits implementations to a given type `$ty`
@@ -76,14 +78,14 @@ macro_rules! engine_input_impl(
         #[cfg(not(fuzzing))]
         fn input(&mut self, mut inp: &[u8]) {
             while !inp.is_empty() {
-                let buf_idx = self.length % <Self as EngineTrait>::BLOCK_SIZE;
-                let rem_len = <Self as EngineTrait>::BLOCK_SIZE - buf_idx;
+                let buf_idx = self.length % <Self as crate::HashEngine>::BLOCK_SIZE;
+                let rem_len = <Self as crate::HashEngine>::BLOCK_SIZE - buf_idx;
                 let write_len = cmp::min(rem_len, inp.len());
 
                 self.buffer[buf_idx..buf_idx + write_len]
                     .copy_from_slice(&inp[..write_len]);
                 self.length += write_len;
-                if self.length % <Self as EngineTrait>::BLOCK_SIZE == 0 {
+                if self.length % <Self as crate::HashEngine>::BLOCK_SIZE == 0 {
                     self.process_block();
                 }
                 inp = &inp[write_len..];
@@ -289,8 +291,8 @@ pub mod json_hex_string {
 
 #[cfg(test)]
 mod test {
-    use Hash;
-    use sha256;
+    use crate::{Hash, sha256};
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Update the MSRV to Rustn 1.41.1 and enable edition 2018.

Should not be merged without rust-bitcoin organization-wide planning on how to go about this upgrade.

Discussion: https://github.com/rust-bitcoin/rust-bitcoin/issues/510#issuecomment-881686342

This one is a bit more involved than the same PRs for [rust-bech32](https://github.com/rust-bitcoin/rust-bech32/pull/57) or [rust-bitcoinconcensus](https://github.com/rust-bitcoin/rust-bitcoinconsensus/pull/34).

The commit message of patch 3:
```
Update to use edition 2018

Add `edition = "2018"` to the minifest file. In order to get the
codebase to build cleanly do:

- Remove usage of `use Hash as HashTrait`, instead use `impl crate::Hash for Hash` and `use Hash as _`.
- Same for HashEngine (remove EngineTrait).
- Add `crate::` to import statements and group same level (only did this for crate imports, the rest can wait for rustfmt :)
- Make test imports uniform, elect to _not_ use `super::*` because it seems cleaner, we are always importing the module we are testing and the same set of traits in each `test` module. Can change if requested.
```

Thanks