### PR TITLE
Allow unknown lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,9 @@
 //! are needed to display hashes anway.
 //!
 
+// Unknown lint warnings occur when linting with an old version of clippy and
+// hitting code that allows a lint that exists only in newer versions of clippy.
+#![allow(unknown_lints)]
 // Coding conventions
 #![deny(non_upper_case_globals)]
 #![deny(non_camel_case_types)]


### PR DESCRIPTION
We support many versions of rustc by design, this puts us in the following predicament:

1. Linting with a newer version of clippy throws a warning for a newly introduced default lint.
2. In order to allow the lint we must use the lint by name but this lint does not exist in earlier versions of clippy, so we get a warning `unknown lint` when linting with the earlier version.

We want to have our cake and eat it too, we can do this by allowing unknown lints. Doing so enables (1) while preventing (2).

If this PR is deemed a good solution we can do the same in `rust-secp256k1` and `rust-bitcoin`.