### PR TITLE
Add a disabled rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+disable_all_formatting = true


### PR DESCRIPTION
We do not currently use `rustfmt`, this is a nuisance for devs who routinely work on code bases that do use rustfmt who often have their editors set to format on save. We can make the life of such devs much better by explicitly disabling formatting using `rustfmt.toml`.

ref: https://rust-lang.github.io/rustfmt/?version=v1.4.38&search=#disable_all_formatting