### PR TITLE
Use SliceIndex trait to implement Index

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -20,6 +20,8 @@
 //! # HASH160 (SHA256 then RIPEMD160)
 
 use core::str;
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use sha256;
 use ripemd160;
@@ -40,9 +42,17 @@ pub struct Hash(
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -20,6 +20,8 @@
 //! # RIPEMD160
 
 use core::{cmp, str};
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use HashEngine as EngineTrait;
 use Hash as HashTrait;
@@ -86,9 +88,17 @@ pub struct Hash(
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -15,6 +15,8 @@
 //! # SHA1
 
 use core::{cmp, str};
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use HashEngine as EngineTrait;
 use Hash as HashTrait;
@@ -81,9 +83,17 @@ pub struct Hash(
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -15,6 +15,8 @@
 //! # SHA256
 
 use core::{cmp, str};
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use hex;
 use HashEngine as EngineTrait;
@@ -89,9 +91,17 @@ impl str::FromStr for Hash {
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl HashTrait for Hash {
     type Engine = HashEngine;
@@ -160,9 +170,17 @@ pub struct Midstate(pub [u8; 32]);
 hex_fmt_impl!(Debug, Midstate);
 hex_fmt_impl!(Display, Midstate);
 hex_fmt_impl!(LowerHex, Midstate);
-index_impl!(Midstate);
 serde_impl!(Midstate, 32);
 borrow_slice_impl!(Midstate);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl str::FromStr for Midstate {
     type Err = ::hex::Error;

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -15,6 +15,8 @@
 //! # SHA256d
 
 use core::str;
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use sha256;
 use Hash as HashTrait;
@@ -32,9 +34,17 @@ pub struct Hash(
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -17,6 +17,8 @@
 use core::{cmp, str};
 #[cfg(feature="serde")] use core::fmt;
 use core::marker::PhantomData;
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use sha256;
 use Hash as HashTrait;
@@ -83,8 +85,16 @@ impl<T: Tag> str::FromStr for Hash<T> {
 hex_fmt_impl!(Debug, Hash, T:Tag);
 hex_fmt_impl!(Display, Hash, T:Tag);
 hex_fmt_impl!(LowerHex, Hash, T:Tag);
-index_impl!(Hash, T:Tag);
 borrow_slice_impl!(Hash, T:Tag);
+
+impl<I: SliceIndex<[u8]>, T: Tag> Index<I> for Hash<T> {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl<T: Tag> HashTrait for Hash<T> {
     type Engine = sha256::HashEngine;

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -20,6 +20,8 @@
 //! # SHA512
 
 use core::{cmp, hash, str};
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use HashEngine as EngineTrait;
 use Hash as HashTrait;
@@ -137,9 +139,17 @@ impl str::FromStr for Hash {
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 64);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl HashTrait for Hash {
     type Engine = HashEngine;

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -20,6 +20,8 @@
 //! # SipHash 2-4
 
 use core::{cmp, mem, ptr, str};
+use core::ops::Index;
+use core::slice::SliceIndex;
 
 use Error;
 use Hash as HashTrait;
@@ -206,9 +208,17 @@ pub struct Hash(
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
-index_impl!(Hash);
 serde_impl!(Hash, 8);
 borrow_slice_impl!(Hash);
+
+impl<I: SliceIndex<[u8]>> Index<I> for Hash {
+    type Output = I::Output;
+
+    #[inline]
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
+}
 
 impl str::FromStr for Hash {
     type Err = ::hex::Error;

--- a/src/util.rs
+++ b/src/util.rs
@@ -42,50 +42,6 @@ macro_rules! hex_fmt_impl(
     )
 );
 
-/// Adds `core::ops::Index` trait implementation to a given type `$ty`
-#[macro_export]
-macro_rules! index_impl(
-    ($ty:ident) => (
-        index_impl!($ty, );
-    );
-    ($ty:ident, $($gen:ident: $gent:ident),*) => (
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Index<usize> for $ty<$($gen),*> {
-            type Output = u8;
-            fn index(&self, index: usize) -> &u8 {
-                &self.0[index]
-            }
-        }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Index<$crate::_export::_core::ops::Range<usize>> for $ty<$($gen),*> {
-            type Output = [u8];
-            fn index(&self, index: $crate::_export::_core::ops::Range<usize>) -> &[u8] {
-                &self.0[index]
-            }
-        }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Index<$crate::_export::_core::ops::RangeFrom<usize>> for $ty<$($gen),*> {
-            type Output = [u8];
-            fn index(&self, index: $crate::_export::_core::ops::RangeFrom<usize>) -> &[u8] {
-                &self.0[index]
-            }
-        }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Index<$crate::_export::_core::ops::RangeTo<usize>> for $ty<$($gen),*> {
-            type Output = [u8];
-            fn index(&self, index: $crate::_export::_core::ops::RangeTo<usize>) -> &[u8] {
-                &self.0[index]
-            }
-        }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Index<$crate::_export::_core::ops::RangeFull> for $ty<$($gen),*> {
-            type Output = [u8];
-            fn index(&self, index: $crate::_export::_core::ops::RangeFull) -> &[u8] {
-                &self.0[index]
-            }
-        }
-    )
-);
-
 /// Adds slicing traits implementations to a given type `$ty`
 #[macro_export]
 macro_rules! borrow_slice_impl(
@@ -224,7 +180,6 @@ macro_rules! hash_newtype {
         hex_fmt_impl!(Debug, $newtype);
         hex_fmt_impl!(Display, $newtype);
         hex_fmt_impl!(LowerHex, $newtype);
-        index_impl!($newtype);
         serde_impl!($newtype, $len);
         borrow_slice_impl!($newtype);
 
@@ -294,6 +249,15 @@ macro_rules! hash_newtype {
             type Err = $crate::hex::Error;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
                 $crate::hex::FromHex::from_hex(s)
+            }
+        }
+
+        impl<I: $crate::_export::_core::slice::SliceIndex<[u8]>> $crate::_export::_core::ops::Index<I> for $newtype {
+            type Output = I::Output;
+
+            #[inline]
+            fn index(&self, index: I) -> &Self::Output {
+                &self.0[index]
             }
         }
     };


### PR DESCRIPTION
Since we bumped to Rust 1.29 it has not been necessary to implement `Index` manually, we can get it by way of the `SliceIndex` trait.

Implement `Index` using `SliceIndex`. Keep the declarative macro so we only have to write the `SliceIndex` implementation once.

This is in the same vein as https://github.com/rust-bitcoin/rust-bitcoin/pull/805 but goes about it in a slightly different manner, we should probably be uniform across both crates. I'm unsure which is the best option?