### PR TITLE
Do manual rustfmt cleanups

### DIFF
--- a/fuzz/fuzz_targets/cbor.rs
+++ b/fuzz/fuzz_targets/cbor.rs
@@ -27,11 +27,11 @@ fn do_test(data: &[u8]) {
     }
 }
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 #[macro_use]
 extern crate honggfuzz;
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|d| { do_test(d) });

--- a/fuzz/fuzz_targets/json.rs
+++ b/fuzz/fuzz_targets/json.rs
@@ -27,11 +27,11 @@ fn do_test(data: &[u8]) {
     }
 }
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 #[macro_use]
 extern crate honggfuzz;
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|d| { do_test(d) });

--- a/fuzz/fuzz_targets/ripemd160.rs
+++ b/fuzz/fuzz_targets/ripemd160.rs
@@ -18,11 +18,11 @@ fn do_test(data: &[u8]) {
     assert_eq!(&our_hash[..], &rc_hash[..]);
 }
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 #[macro_use]
 extern crate honggfuzz;
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|d| { do_test(d) });

--- a/fuzz/fuzz_targets/sha1.rs
+++ b/fuzz/fuzz_targets/sha1.rs
@@ -18,11 +18,11 @@ fn do_test(data: &[u8]) {
     assert_eq!(&our_hash[..], &rc_hash[..]);
 }
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 #[macro_use]
 extern crate honggfuzz;
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|d| { do_test(d) });

--- a/fuzz/fuzz_targets/sha256.rs
+++ b/fuzz/fuzz_targets/sha256.rs
@@ -18,11 +18,11 @@ fn do_test(data: &[u8]) {
     assert_eq!(&our_hash[..], &rc_hash[..]);
 }
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 #[macro_use]
 extern crate honggfuzz;
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|d| { do_test(d) });

--- a/fuzz/fuzz_targets/sha512.rs
+++ b/fuzz/fuzz_targets/sha512.rs
@@ -18,11 +18,11 @@ fn do_test(data: &[u8]) {
     assert_eq!(&our_hash[..], &rc_hash[..]);
 }
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 #[macro_use]
 extern crate honggfuzz;
 
-#[cfg(feature="honggfuzz")]
+#[cfg(feature = "honggfuzz")]
 fn main() {
     loop {
         fuzz!(|d| { do_test(d) });

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -79,7 +79,7 @@ fn eq_test() {
     assert!(!fixed_time_eq(&[0b00000000, 0b00000000], &[0b00000001, 0b00000001]));
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -44,16 +44,16 @@ pub fn fixed_time_eq(a: &[u8], b: &[u8]) -> bool {
 
 #[test]
 fn eq_test() {
-    assert!( fixed_time_eq(&[0b00000000], &[0b00000000]));
-    assert!( fixed_time_eq(&[0b00000001], &[0b00000001]));
-    assert!( fixed_time_eq(&[0b00000010], &[0b00000010]));
-    assert!( fixed_time_eq(&[0b00000100], &[0b00000100]));
-    assert!( fixed_time_eq(&[0b00001000], &[0b00001000]));
-    assert!( fixed_time_eq(&[0b00010000], &[0b00010000]));
-    assert!( fixed_time_eq(&[0b00100000], &[0b00100000]));
-    assert!( fixed_time_eq(&[0b01000000], &[0b01000000]));
-    assert!( fixed_time_eq(&[0b10000000], &[0b10000000]));
-    assert!( fixed_time_eq(&[0b11111111], &[0b11111111]));
+    assert!(fixed_time_eq(&[0b00000000], &[0b00000000]));
+    assert!(fixed_time_eq(&[0b00000001], &[0b00000001]));
+    assert!(fixed_time_eq(&[0b00000010], &[0b00000010]));
+    assert!(fixed_time_eq(&[0b00000100], &[0b00000100]));
+    assert!(fixed_time_eq(&[0b00001000], &[0b00001000]));
+    assert!(fixed_time_eq(&[0b00010000], &[0b00010000]));
+    assert!(fixed_time_eq(&[0b00100000], &[0b00100000]));
+    assert!(fixed_time_eq(&[0b01000000], &[0b01000000]));
+    assert!(fixed_time_eq(&[0b10000000], &[0b10000000]));
+    assert!(fixed_time_eq(&[0b11111111], &[0b11111111]));
 
     assert!(!fixed_time_eq(&[0b00000001], &[0b00000000]));
     assert!(!fixed_time_eq(&[0b00000001], &[0b11111111]));

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -31,7 +31,7 @@ use Error;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_20"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_20"))]
     [u8; 20]
 );
 
@@ -147,7 +147,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn ripemd_serde() {
 
@@ -167,7 +167,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -176,7 +176,7 @@ mod benches {
     use HashEngine;
 
     #[bench]
-    pub fn hash160_10(bh: & mut Bencher) {
+    pub fn hash160_10(bh: &mut Bencher) {
         let mut engine = hash160::Hash::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -186,7 +186,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn hash160_1k(bh: & mut Bencher) {
+    pub fn hash160_1k(bh: &mut Bencher) {
         let mut engine = hash160::Hash::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -196,7 +196,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn hash160_64k(bh: & mut Bencher) {
+    pub fn hash160_64k(bh: &mut Bencher) {
         let mut engine = hash160::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -35,8 +35,6 @@ pub struct Hash(
     [u8; 20]
 );
 
-
-
 hex_fmt_impl!(Debug, Hash);
 hex_fmt_impl!(Display, Hash);
 hex_fmt_impl!(LowerHex, Hash);
@@ -199,7 +197,6 @@ mod benches {
 
     #[bench]
     pub fn hash160_64k(bh: & mut Bencher) {
-
         let mut engine = hash160::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {
@@ -207,5 +204,4 @@ mod benches {
         });
         bh.bytes = bytes.len() as u64;
     }
-
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -60,9 +60,8 @@ pub trait ToHex {
 pub trait FromHex: Sized {
     /// Produce an object from a byte iterator
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-        where I: Iterator<Item=Result<u8, Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator;
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator;
 
     /// Produce an object from a hex string
     fn from_hex(s: &str) -> Result<Self, Error> {
@@ -80,9 +79,8 @@ impl<T: fmt::LowerHex> ToHex for T {
 
 impl<T: Hash> FromHex for T {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-        where I: Iterator<Item=Result<u8, Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
     {
         let inner;
         if Self::DISPLAY_BACKWARD {
@@ -216,9 +214,8 @@ impl ToHex for [u8] {
 #[cfg(any(test, feature = "std", feature = "alloc"))]
 impl FromHex for Vec<u8> {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-        where I: Iterator<Item=Result<u8, Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
+    where
+        I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
     {
         iter.collect()
     }
@@ -228,9 +225,8 @@ macro_rules! impl_fromhex_array {
     ($len:expr) => {
         impl FromHex for [u8; $len] {
             fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
-                where I: Iterator<Item=Result<u8, Error>> +
-                    ExactSizeIterator +
-                    DoubleEndedIterator,
+            where
+                I: Iterator<Item = Result<u8, Error>> + ExactSizeIterator + DoubleEndedIterator,
             {
                 if iter.len() == $len {
                     let mut ret = [0; $len];

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -136,7 +136,7 @@ impl<'a> Iterator for HexIterator<'a> {
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (min, max) = self.iter.size_hint();
-        (min / 2, max.map(|x| x /2))
+        (min / 2, max.map(|x| x / 2))
     }
 }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -397,7 +397,7 @@ mod benches {
     use {Hmac, Hash, HashEngine};
 
     #[bench]
-    pub fn hmac_sha256_10(bh: & mut Bencher) {
+    pub fn hmac_sha256_10(bh: &mut Bencher) {
         let mut engine = Hmac::<sha256::Hash>::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -407,7 +407,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn hmac_sha256_1k(bh: & mut Bencher) {
+    pub fn hmac_sha256_1k(bh: &mut Bencher) {
         let mut engine = Hmac::<sha256::Hash>::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -417,7 +417,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn hmac_sha256_64k(bh: & mut Bencher) {
+    pub fn hmac_sha256_64k(bh: &mut Bencher) {
         let mut engine = Hmac::<sha256::Hash>::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -20,7 +20,7 @@
 //! # HMAC support
 
 use core::{borrow, fmt, ops, str};
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
 
 use HashEngine as EngineTrait;
@@ -218,14 +218,14 @@ impl<T: HashTrait> HashTrait for Hmac<T> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(&self.0, s)
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Hmac<T>, D::Error> {
         let inner = Deserialize::deserialize(d)?;
@@ -236,7 +236,7 @@ impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
 #[cfg(test)]
 mod tests {
     use sha256;
-    #[cfg(feature="serde")] use sha512;
+    #[cfg(feature = "serde")] use sha512;
     use {Hash, HashEngine, Hmac, HmacEngine};
 
     #[derive(Clone)]
@@ -361,7 +361,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn hmac_sha512_serde() {
         use serde_test::{Configure, Token, assert_tokens};
@@ -389,7 +389,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,12 +37,12 @@
 #![cfg_attr(all(test, feature = "unstable"), feature(test))]
 #[cfg(all(test, feature = "unstable"))] extern crate test;
 
-#[cfg(any(test, feature="std"))] extern crate core;
-#[cfg(feature="core2")] extern crate core2;
+#[cfg(any(test, feature = "std"))] extern crate core;
+#[cfg(feature = "core2")] extern crate core2;
 #[cfg(feature = "alloc")] extern crate alloc;
 #[cfg(all(not(feature = "alloc"), feature = "std"))] use std as alloc;
-#[cfg(feature="serde")] pub extern crate serde;
-#[cfg(all(test,feature="serde"))] extern crate serde_test;
+#[cfg(feature = "serde")] pub extern crate serde;
+#[cfg(all(test,feature = "serde"))] extern crate serde_test;
 
 #[doc(hidden)]
 pub mod _export {

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -79,7 +79,7 @@ impl EngineTrait for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_20"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_20"))]
     [u8; 20]
 );
 
@@ -530,7 +530,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn ripemd_serde() {
         use serde_test::{Configure, Token, assert_tokens};
@@ -549,7 +549,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -558,7 +558,7 @@ mod benches {
     use HashEngine;
 
     #[bench]
-    pub fn ripemd160_10(bh: & mut Bencher) {
+    pub fn ripemd160_10(bh: &mut Bencher) {
         let mut engine = ripemd160::Hash::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -568,7 +568,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn ripemd160_1k(bh: & mut Bencher) {
+    pub fn ripemd160_1k(bh: &mut Bencher) {
         let mut engine = ripemd160::Hash::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -578,7 +578,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn ripemd160_64k(bh: & mut Bencher) {
+    pub fn ripemd160_64k(bh: &mut Bencher) {
         let mut engine = ripemd160::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -283,7 +283,7 @@ mod benches {
     use HashEngine;
 
     #[bench]
-    pub fn sha1_10(bh: & mut Bencher) {
+    pub fn sha1_10(bh: &mut Bencher) {
         let mut engine = sha1::Hash::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -293,7 +293,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha1_1k(bh: & mut Bencher) {
+    pub fn sha1_1k(bh: &mut Bencher) {
         let mut engine = sha1::Hash::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -303,7 +303,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha1_64k(bh: & mut Bencher) {
+    pub fn sha1_64k(bh: &mut Bencher) {
         let mut engine = sha1::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -74,7 +74,7 @@ impl EngineTrait for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_20"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_20"))]
     [u8; 20]
 );
 
@@ -255,7 +255,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn sha1_serde() {
         use serde_test::{Configure, Token, assert_tokens};
@@ -274,7 +274,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -108,7 +108,7 @@ impl HashTrait for Hash {
         let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
         e.input(&zeroes[..pad_length]);
         debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
-        
+
         e.input(&util::u64_to_array_be(8 * data_len));
         debug_assert_eq!(e.length % BLOCK_SIZE, 0);
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -533,7 +533,7 @@ mod benches {
     use HashEngine;
 
     #[bench]
-    pub fn sha256_10(bh: & mut Bencher) {
+    pub fn sha256_10(bh: &mut Bencher) {
         let mut engine = sha256::Hash::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -543,7 +543,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha256_1k(bh: & mut Bencher) {
+    pub fn sha256_1k(bh: &mut Bencher) {
         let mut engine = sha256::Hash::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -553,7 +553,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha256_64k(bh: & mut Bencher) {
+    pub fn sha256_64k(bh: &mut Bencher) {
         let mut engine = sha256::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -204,9 +204,8 @@ impl Midstate {
 
 impl hex::FromHex for Midstate {
     fn from_byte_iter<I>(iter: I) -> Result<Self, hex::Error>
-        where I: Iterator<Item=Result<u8, hex::Error>> +
-            ExactSizeIterator +
-            DoubleEndedIterator,
+    where
+        I: Iterator<Item = Result<u8, hex::Error>> + ExactSizeIterator + DoubleEndedIterator,
     {
         // DISPLAY_BACKWARD is true
         Ok(Midstate::from_inner(hex::FromHex::from_byte_iter(iter.rev())?))

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -75,7 +75,7 @@ impl EngineTrait for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_32"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_32"))]
     [u8; 32]
 );
 
@@ -493,7 +493,7 @@ mod tests {
         assert_eq!(hash, sha256::Hash(HASH_EXPECTED));
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn sha256_serde() {
         use serde_test::{Configure, Token, assert_tokens};
@@ -524,7 +524,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -94,14 +94,14 @@ mod tests {
     use Hash;
     use HashEngine;
 
-#[derive(Clone)]
+    #[derive(Clone)]
     struct Test {
-input: &'static str,
-           output: Vec<u8>,
-           output_str: &'static str,
+        input: &'static str,
+        output: Vec<u8>,
+        output_str: &'static str,
     }
 
-#[test]
+    #[test]
     fn test() {
         let tests = vec![
             // Test vector copied out of rust-bitcoin

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -162,7 +162,7 @@ mod benches {
     use HashEngine;
 
     #[bench]
-    pub fn sha256d_10(bh: & mut Bencher) {
+    pub fn sha256d_10(bh: &mut Bencher) {
         let mut engine = sha256d::Hash::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -172,7 +172,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha256d_1k(bh: & mut Bencher) {
+    pub fn sha256d_1k(bh: &mut Bencher) {
         let mut engine = sha256d::Hash::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -182,7 +182,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha256d_64k(bh: & mut Bencher) {
+    pub fn sha256d_64k(bh: &mut Bencher) {
         let mut engine = sha256d::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -25,7 +25,7 @@ use Error;
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_32"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_32"))]
     [u8; 32]
 );
 
@@ -135,7 +135,7 @@ input: &'static str,
         }
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn sha256_serde() {
         use serde_test::{Configure, Token, assert_tokens};
@@ -153,7 +153,7 @@ input: &'static str,
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -175,8 +175,8 @@ impl<'de, T: Tag> ::serde::de::Visitor<'de> for HexVisitor<T> {
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-        where
-            E: ::serde::de::Error,
+    where
+        E: ::serde::de::Error,
     {
         use core::str::FromStr;
         if let Ok(hex) = str::from_utf8(v) {
@@ -187,8 +187,8 @@ impl<'de, T: Tag> ::serde::de::Visitor<'de> for HexVisitor<T> {
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-        where
-            E: ::serde::de::Error,
+    where
+        E: ::serde::de::Error,
     {
         use core::str::FromStr;
         Hash::<T>::from_str(v).map_err(E::custom)
@@ -212,8 +212,8 @@ impl<'de, T: Tag> ::serde::de::Visitor<'de> for BytesVisitor<T> {
     }
 
     fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
-        where
-            E: ::serde::de::Error,
+    where
+        E: ::serde::de::Error,
     {
         Hash::<T>::from_slice(v).map_err(|_| {
             // from_slice only errors on incorrect length

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -15,7 +15,7 @@
 //! # SHA256t (tagged SHA256)
 
 use core::{cmp, str};
-#[cfg(feature="serde")] use core::fmt;
+#[cfg(feature = "serde")] use core::fmt;
 use core::marker::PhantomData;
 
 use sha256;
@@ -34,7 +34,7 @@ pub trait Tag {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash<T: Tag>(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="crate::util::json_hex_string::len_32"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_32"))]
     [u8; 32],
     #[cfg_attr(feature = "schemars", schemars(skip))]
     PhantomData<T>
@@ -147,7 +147,7 @@ macro_rules! sha256t_hash_newtype {
     };
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<T: Tag> ::serde::Serialize for Hash<T> {
     fn serialize<S: ::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         if s.is_human_readable() {
@@ -158,15 +158,15 @@ impl<T: Tag> ::serde::Serialize for Hash<T> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 struct HexVisitor<T: Tag>(PhantomData<T>);
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<T: Tag> Default for HexVisitor<T> {
     fn default() -> Self { HexVisitor(PhantomData) }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: Tag> ::serde::de::Visitor<'de> for HexVisitor<T> {
     type Value = Hash<T>;
 
@@ -195,15 +195,15 @@ impl<'de, T: Tag> ::serde::de::Visitor<'de> for HexVisitor<T> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 struct BytesVisitor<T: Tag>(PhantomData<T>);
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<T: Tag> Default for BytesVisitor<T> {
     fn default() -> Self { BytesVisitor(PhantomData) }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: Tag> ::serde::de::Visitor<'de> for BytesVisitor<T> {
     type Value = Hash<T>;
 
@@ -222,7 +222,7 @@ impl<'de, T: Tag> ::serde::de::Visitor<'de> for BytesVisitor<T> {
     }
 }
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 impl<'de, T: Tag> ::serde::Deserialize<'de> for Hash<T> {
     fn deserialize<D: ::serde::Deserializer<'de>>(d: D) -> Result<Hash<T>, D::Error> {
         if d.is_human_readable() {

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -262,13 +262,13 @@ mod tests {
 
     #[test]
     fn test_sha256t() {
-       assert_eq!(
-           TestHash::hash(&[0]).to_hex(),
-           "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
-       );
-       assert_eq!(
-           NewTypeHash::hash(&[0]).to_hex(),
-           "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
-       );
+        assert_eq!(
+            TestHash::hash(&[0]).to_hex(),
+            "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
+        );
+        assert_eq!(
+            NewTypeHash::hash(&[0]).to_hex(),
+            "29589d5122ec666ab5b4695070b6debc63881a4f85d88d93ddc90078038213ed"
+        );
     }
 }

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -452,7 +452,7 @@ mod benches {
     use HashEngine;
 
     #[bench]
-    pub fn sha512_10(bh: & mut Bencher) {
+    pub fn sha512_10(bh: &mut Bencher) {
         let mut engine = sha512::Hash::engine();
         let bytes = [1u8; 10];
         bh.iter( || {
@@ -462,7 +462,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha512_1k(bh: & mut Bencher) {
+    pub fn sha512_1k(bh: &mut Bencher) {
         let mut engine = sha512::Hash::engine();
         let bytes = [1u8; 1024];
         bh.iter( || {
@@ -472,7 +472,7 @@ mod benches {
     }
 
     #[bench]
-    pub fn sha512_64k(bh: & mut Bencher) {
+    pub fn sha512_64k(bh: &mut Bencher) {
         let mut engine = sha512::Hash::engine();
         let bytes = [1u8; 65536];
         bh.iter( || {

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -81,7 +81,7 @@ impl EngineTrait for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_64"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_64"))]
     [u8; 64]
 );
 
@@ -415,7 +415,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature="serde")]
+    #[cfg(feature = "serde")]
     #[test]
     fn sha512_serde() {
         use serde_test::{Configure, Token, assert_tokens};
@@ -443,7 +443,7 @@ mod tests {
     }
 }
 
-#[cfg(all(test, feature="unstable"))]
+#[cfg(all(test, feature = "unstable"))]
 mod benches {
     use test::Bencher;
 

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -199,7 +199,7 @@ impl EngineTrait for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with="util::json_hex_string::len_8"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_8"))]
     [u8; 8]
 );
 


### PR DESCRIPTION
Use `rustfmt` to highlight areas in the code that can be cleaned up. All patches are refactor only, no logic changes.

Non-urgent PR.