### PR TITLE
Add all_zeros method to Hash trait

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -30,7 +30,7 @@ use Hash as HashTrait;
 use Error;
 
 /// Output of the Bitcoin HASH160 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -99,6 +99,10 @@ impl HashTrait for Hash {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
+    }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 20])
     }
 }
 

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -29,7 +29,7 @@ use Hash as HashTrait;
 use Error;
 
 /// A hash computed from a RFC 2104 HMAC. Parameterized by the underlying hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "schemars", schemars(transparent))]
 #[repr(transparent)]
@@ -219,6 +219,11 @@ impl<T: HashTrait> HashTrait for Hmac<T> {
 
     fn from_inner(inner: T::Inner) -> Self {
         Hmac(T::from_inner(inner))
+    }
+
+    fn all_zeros() -> Self {
+        let zeros = T::all_zeros();
+        Hmac(zeros)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ pub trait HashEngine: Clone + Default {
 }
 
 /// Trait which applies to hashes of all types.
-pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
+pub trait Hash: Copy + Clone + PartialEq + Eq + PartialOrd + Ord +
     hash::Hash + fmt::Debug + fmt::Display + fmt::LowerHex +
     ops::Index<ops::RangeFull, Output = [u8]> +
     ops::Index<ops::RangeFrom<usize>, Output = [u8]> +
@@ -146,6 +146,13 @@ pub trait Hash: Copy + Clone + PartialEq + Eq + Default + PartialOrd + Ord +
 
     /// Constructs a hash from the underlying byte array.
     fn from_inner(inner: Self::Inner) -> Self;
+
+    /// Returns an all zero hash.
+    ///
+    /// An all zeros hash is a made up construct because there is not a known input that can create
+    /// it, however it is used in various places in Bitcoin e.g., the Bitcoin genesis block's
+    /// previous blockhash and the coinbase transaction's outpoint txid.
+    fn all_zeros() -> Self;
 }
 
 #[cfg(test)]

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -78,7 +78,7 @@ impl EngineTrait for HashEngine {
 }
 
 /// Output of the RIPEMD160 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -161,6 +161,10 @@ impl HashTrait for Hash {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
+    }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 20])
     }
 }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -73,7 +73,7 @@ impl EngineTrait for HashEngine {
 }
 
 /// Output of the SHA1 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -148,6 +148,10 @@ impl HashTrait for Hash {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
+    }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 20])
     }
 }
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -74,7 +74,7 @@ impl EngineTrait for HashEngine {
 }
 
 /// Output of the SHA256 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -161,6 +161,10 @@ impl HashTrait for Hash {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
+    }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 32])
     }
 }
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -24,7 +24,7 @@ use Hash as HashTrait;
 use Error;
 
 /// Output of the SHA256d hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -95,6 +95,10 @@ impl HashTrait for Hash {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
+    }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 32])
     }
 }
 

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -134,6 +134,10 @@ impl<T: Tag> HashTrait for Hash<T> {
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner, PhantomData)
     }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 32], PhantomData)
+    }
 }
 
 /// Macro used to define a newtype tagged hash.

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -207,6 +207,10 @@ impl HashTrait for Hash {
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
     }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 64])
+    }
 }
 
 macro_rules! Ch( ($x:expr, $y:expr, $z:expr) => ($z ^ ($x & ($y ^ $z))) );

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -198,7 +198,7 @@ impl EngineTrait for HashEngine {
 }
 
 /// Output of the SipHash24 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
@@ -308,6 +308,10 @@ impl HashTrait for Hash {
 
     fn from_inner(inner: Self::Inner) -> Self {
         Hash(inner)
+    }
+
+    fn all_zeros() -> Self {
+        Hash([0x00; 8])
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -173,7 +173,7 @@ macro_rules! hash_newtype {
     };
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta, $reverse:expr) => {
         #[$docs]
-        #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
+        #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
         #[repr(transparent)]
         pub struct $newtype($hash);
 
@@ -242,6 +242,12 @@ macro_rules! hash_newtype {
             #[inline]
             fn as_inner(&self) -> &Self::Inner {
                 self.0.as_inner()
+            }
+
+            #[inline]
+            fn all_zeros() -> Self {
+                let zeros = <$hash>::all_zeros();
+                $newtype(zeros)
             }
         }
 


### PR DESCRIPTION
Currently we use `Default::default()` to get an all zeros hash. This is confusing because an all zeroes hash does not have a real meaning since there is no known input to create it. The all zeros hash is, however used by the Bitcoin network to signify certain things (e.g. the previous blockhash in the genesis block).

Remove the `Default` implementation from the `Hash` trait and add a `all_zeros` method instead. Remove the `Default` derive from any hash type that has it.

To see the patch to `rust-bitcoin` that this PR imposes, check out [this branch](https://github.com/tcharding/rust-bitcoin/tree/bitcoin_hashes-all-zeros).

Resolves #139 