### PR TITLE
Build docs using nightly toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,8 +3,8 @@ on: [push, pull_request]
 name: Continuous integration
 
 jobs:
-  bench_nightly:
-    name: Nightly - ASan + Bench
+  Nightly:
+    name: Nightly - ASan + Bench + Docs
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -28,9 +28,13 @@ jobs:
         env:
           DO_BENCH: true
         run: ./contrib/test.sh
+      - name: Building docs
+        env:
+          DO_DOCS: true
+        run: ./contrib/test.sh
 
-  wasm: 
-    name: Stable - Docs / WebAssembly Build
+  wasm:
+    name: Stable - WebAssembly Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,10 +49,6 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Building docs
-        env:
-          DO_DOCS: true
-        run: ./contrib/test.sh
       - name: Running WASM build
         env:
           DO_WASM: true

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -51,9 +51,9 @@ if [ "$DO_SCHEMARS_TESTS" = true ]; then
     (cd extended_tests/schemars && cargo test)
 fi
 
-# Docs
+# Build the docs if told to (this only works with the nightly toolchain)
 if [ "$DO_DOCS" = true ]; then
-    cargo doc --all --features="$FEATURES"
+    RUSTDOCFLAGS="--cfg docsrs" cargo doc --all --features="$FEATURES"
 fi
 
 # Webassembly stuff


### PR DESCRIPTION
In order to get access to the `--cfg docsrs` we need to use the nightly
toolchain. Doing so means the CI docs build mirrors the docsrs docs
build so better tests our docs build prior to release.