### PR TITLE
Use nightly docs features

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -51,6 +51,7 @@ impl fmt::Display for Error {
 
 /// Trait for objects that can be serialized as hex strings.
 #[cfg(any(test, feature = "std", feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(any(test, feature = "std", feature = "alloc"))))]
 pub trait ToHex {
     /// Converts to a hexadecimal representation of the object.
     fn to_hex(&self) -> String;
@@ -70,6 +71,7 @@ pub trait FromHex: Sized {
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(any(test, feature = "std", feature = "alloc"))))]
 impl<T: fmt::LowerHex> ToHex for T {
     /// Outputs the hash in hexadecimal form.
     fn to_hex(&self) -> String {
@@ -142,6 +144,7 @@ impl<'a> Iterator for HexIterator<'a> {
 }
 
 #[cfg(any(feature = "std", feature = "core2"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "core2"))))]
 impl<'a> io::Read for HexIterator<'a> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut bytes_read = 0usize;
@@ -205,6 +208,7 @@ pub fn format_hex_reverse(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(any(test, feature = "std", feature = "alloc"))))]
 impl ToHex for [u8] {
     fn to_hex(&self) -> String {
         use core::fmt::Write;
@@ -217,6 +221,7 @@ impl ToHex for [u8] {
 }
 
 #[cfg(any(test, feature = "std", feature = "alloc"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "alloc"))))]
 impl FromHex for Vec<u8> {
     fn from_byte_iter<I>(iter: I) -> Result<Self, Error>
     where

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -204,7 +204,7 @@ pub fn format_hex_reverse(data: &[u8], f: &mut fmt::Formatter) -> fmt::Result {
     Ok(())
 }
 
-#[cfg(any(test, feature = "alloc", feature = "std"))]
+#[cfg(any(test, feature = "std", feature = "alloc"))]
 impl ToHex for [u8] {
     fn to_hex(&self) -> String {
         use core::fmt::Write;

--- a/src/hmac.rs
+++ b/src/hmac.rs
@@ -223,6 +223,7 @@ impl<T: HashTrait> HashTrait for Hmac<T> {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
         Serialize::serialize(&self.0, s)
@@ -230,6 +231,7 @@ impl<T: HashTrait + Serialize> Serialize for Hmac<T> {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 impl<'de, T: HashTrait + Deserialize<'de>> Deserialize<'de> for Hmac<T> {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Hmac<T>, D::Error> {
         let inner = Deserialize::deserialize(d)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,9 @@
 #![deny(unused_mut)]
 #![deny(missing_docs)]
 
+// Experimental features we need
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 // In general, rust is absolutely horrid at supporting users doing things like,
 // for example, compiling Rust code for real environments. Disable useless lints
 // that don't do anything but annoy us and cant actually ever be resolved.

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -17,6 +17,7 @@
 
 /// Functions used by serde impls of all hashes.
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde_details {
     use Error;
 
@@ -123,6 +124,7 @@ pub mod serde_details {
 /// represents a newtype over a byte-slice over length `$len`.
 #[macro_export]
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 macro_rules! serde_impl(
     ($t:ident, $len:expr) => (
         impl $crate::serde_macros::serde_details::SerdeHash for $t {
@@ -148,6 +150,7 @@ macro_rules! serde_impl(
 /// Does an "empty" serde implementation for the configuration without serde feature.
 #[macro_export]
 #[cfg(not(feature = "serde"))]
+#[cfg_attr(docsrs, doc(cfg(not(feature = "serde"))))]
 macro_rules! serde_impl(
         ($t:ident, $len:expr) => ()
 );

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -15,8 +15,8 @@
 //! Macros for serde trait implementations, and supporting code.
 //!
 
-#[cfg(feature = "serde")]
 /// Functions used by serde impls of all hashes.
+#[cfg(feature = "serde")]
 pub mod serde_details {
     use Error;
 
@@ -119,10 +119,10 @@ pub mod serde_details {
     }
 }
 
-#[macro_export]
-#[cfg(feature = "serde")]
 /// Implements `Serialize` and `Deserialize` for a type `$t` which
 /// represents a newtype over a byte-slice over length `$len`.
+#[macro_export]
+#[cfg(feature = "serde")]
 macro_rules! serde_impl(
     ($t:ident, $len:expr) => (
         impl $crate::serde_macros::serde_details::SerdeHash for $t {

--- a/src/util.rs
+++ b/src/util.rs
@@ -264,6 +264,7 @@ macro_rules! hash_newtype {
 }
 
 #[cfg(feature = "schemars")]
+#[cfg_attr(docsrs, doc(cfg(feature = "schemars")))]
 pub mod json_hex_string {
     use schemars::schema::{Schema, SchemaObject};
     use schemars::{gen::SchemaGenerator, JsonSchema};


### PR DESCRIPTION
After https://github.com/rust-bitcoin/bitcoin_hashes/pull/150 merges we can use the nightly toolchain and get access to the docrs compiler attribute.

Patch 1 and 2 are cleanup in preparation for patch 3 which adds the experimental docrs cfg attribute of form
```
#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
```
to all non-test code that is feature gated.