### PR TITLE
Add docs to the code create by sha256t_hash_newtype macro

### DIFF
--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -143,7 +143,14 @@ impl<T: Tag> HashTrait for Hash<T> {
 #[macro_export]
 macro_rules! sha256t_hash_newtype {
     ($newtype:ident, $tag:ident, $midstate:ident, $midstate_len:expr, $docs:meta, $reverse: expr) => {
-        /// The tag used for [$newtype].
+        sha256t_hash_newtype!($newtype, $tag, $midstate, $midstate_len, $docs, $reverse, stringify!($newtype));
+    };
+
+    ($newtype:ident, $tag:ident, $midstate:ident, $midstate_len:expr, $docs:meta, $reverse: expr, $sname:expr) => {
+        #[doc = "The tag used for ["]
+        #[doc = $sname]
+        #[doc = "]"]
+        #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
         pub struct $tag;
 
         impl $crate::sha256t::Tag for $tag {


### PR DESCRIPTION
When using the `sha256t_hash_newtype` currently no docs are generated,
this causes lint errors for users who lint for such things.

Add docs to the new type created by the `sha256t_hash_newtype` macro.

(This is identical to how we do it in the duplicate macro of the same
name in `rust-bitcoin`, which can be removed in favour of this one after
this patch is applied.)