### PR TITLE
Update error implementations for the new MSRV

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -31,4 +31,3 @@ impl fmt::Display for Error {
         }
     }
 }
-

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ use core::fmt;
 
 /// Crate error type.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum Error {
     /// Tried to create a fixed-length hash from a slice with the wrong size (expected, got).
     InvalidLength(usize, usize),

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -30,6 +30,7 @@ use crate::Hash;
 
 /// Hex decoding error.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
 pub enum Error {
     /// Non-hexadecimal character.
     InvalidChar(u8),

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -142,24 +142,6 @@ impl<'a> Iterator for HexIterator<'a> {
     }
 }
 
-#[cfg(any(feature = "std", feature = "core2"))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "core2"))))]
-impl<'a> io::Read for HexIterator<'a> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let mut bytes_read = 0usize;
-        for dst in buf {
-            match self.next() {
-                Some(Ok(src)) => {
-                    *dst = src;
-                    bytes_read += 1;
-                },
-                _ => break,
-            }
-        }
-        Ok(bytes_read)
-    }
-}
-
 impl<'a> DoubleEndedIterator for HexIterator<'a> {
     fn next_back(&mut self) -> Option<Result<u8, Error>> {
         let lo = self.iter.next_back()?;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -39,6 +39,22 @@ impl error::Error for hex::Error {
     fn description(&self) -> &str { "`std::error::description` is deprecated" }
 }
 
+impl<'a> io::Read for hex::HexIterator<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut bytes_read = 0usize;
+        for dst in buf {
+            match self.next() {
+                Some(Ok(src)) => {
+                    *dst = src;
+                    bytes_read += 1;
+                },
+                _ => break,
+            }
+        }
+        Ok(bytes_read)
+    }
+}
+
 impl io::Write for sha1::HashEngine {
     fn flush(&mut self) -> io::Result<()> { Ok(()) }
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -26,17 +26,23 @@ use core2::{error, io};
 use crate::{Error, HashEngine, hex, sha1, sha256, sha512, ripemd160, siphash24, hmac};
 
 impl error::Error for Error {
-    #[cfg(feature = "std")]
-    fn cause(&self) -> Option<&error::Error> { None }
-    #[cfg(feature = "std")]
-    fn description(&self) -> &str { "`std::error::description` is deprecated" }
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use Error::*;
+
+        match *self {
+            InvalidLength(_, _) => None
+        }
+    }
 }
 
 impl error::Error for hex::Error {
-    #[cfg(feature = "std")]
-    fn cause(&self) -> Option<&error::Error> { None }
-    #[cfg(feature = "std")]
-    fn description(&self) -> &str { "`std::error::description` is deprecated" }
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        use hex::Error::*;
+
+        match *self {
+            InvalidChar(_) | OddLengthString(_) | InvalidLength(_, _) => None
+        }
+    }
 }
 
 impl<'a> io::Read for hex::HexIterator<'a> {


### PR DESCRIPTION
Implement `source` for all error types (there are only two). Done because we have bumped the MSRV. First two patches are preparatory cleanup.