### PR TITLE
Remove lib section from manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ keywords = [ "crypto", "bitcoin", "hash", "digest" ]
 readme = "README.md"
 edition = "2018"
 
-[lib]
-name = "bitcoin_hashes"
-path = "src/lib.rs"
-
 [features]
 default = ["std"]
 std = []


### PR DESCRIPTION
The lib section we have is the same as the defaults, it is unnecessary.
Now that we are using edition 2018 it makes sense to use the more modern
form and not include an explicit lib section.