### PR TITLE
Fix macro usage in macros

### DIFF
--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -162,7 +162,7 @@ macro_rules! sha256t_hash_newtype {
             }
         }
 
-        hash_newtype!($newtype, $crate::sha256t::Hash<$tag>, 32, $docs, $reverse);
+        $crate::hash_newtype!($newtype, $crate::sha256t::Hash<$tag>, 32, $docs, $reverse);
     };
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -26,7 +26,7 @@ macro_rules! circular_lshift64 (
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(
     ($imp:ident, $ty:ident) => (
-        hex_fmt_impl!($imp, $ty, );
+        $crate::hex_fmt_impl!($imp, $ty, );
     );
     ($imp:ident, $ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::fmt::$imp for $ty<$($gen),*> {
@@ -48,7 +48,7 @@ macro_rules! hex_fmt_impl(
 #[macro_export]
 macro_rules! borrow_slice_impl(
     ($ty:ident) => (
-        borrow_slice_impl!($ty, );
+        $crate::borrow_slice_impl!($ty, );
     );
     ($ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::borrow::Borrow<[u8]> for $ty<$($gen),*>  {
@@ -171,7 +171,7 @@ define_le_to_array!(u64_to_array_le, u64, 8);
 #[macro_export]
 macro_rules! hash_newtype {
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta) => {
-        hash_newtype!($newtype, $hash, $len, $docs, <$hash as $crate::Hash>::DISPLAY_BACKWARD);
+        $crate::hash_newtype!($newtype, $hash, $len, $docs, <$hash as $crate::Hash>::DISPLAY_BACKWARD);
     };
     ($newtype:ident, $hash:ty, $len:expr, $docs:meta, $reverse:expr) => {
         #[$docs]
@@ -179,11 +179,11 @@ macro_rules! hash_newtype {
         #[repr(transparent)]
         pub struct $newtype($hash);
 
-        hex_fmt_impl!(Debug, $newtype);
-        hex_fmt_impl!(Display, $newtype);
-        hex_fmt_impl!(LowerHex, $newtype);
-        serde_impl!($newtype, $len);
-        borrow_slice_impl!($newtype);
+        $crate::hex_fmt_impl!(Debug, $newtype);
+        $crate::hex_fmt_impl!(Display, $newtype);
+        $crate::hex_fmt_impl!(LowerHex, $newtype);
+        $crate::serde_impl!($newtype, $len);
+        $crate::borrow_slice_impl!($newtype);
 
         impl $newtype {
             /// Creates this type from the inner hash type.


### PR DESCRIPTION
Currently we have macros that call other macros without a fully qualified path, this breaks some usage of the macros downstream because macro calls that should be opaque require importing.

Fix macro usage in macros by using `$crate::` fully qualified path.

Done in preparation for removing `extern crate` and `macro_use` in `rust-bitcoin` (since we have edition 2018).