### PR TITLE
use rotate_left function instead of macro

### DIFF
--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -169,8 +169,8 @@ macro_rules! round(
     ($a:expr, $b:expr, $c:expr, $d:expr, $e:expr,
      $x:expr, $bits:expr, $add:expr, $round:expr) => ({
         $a = $a.wrapping_add($round).wrapping_add($x).wrapping_add($add);
-        $a = circular_lshift32!($bits, $a).wrapping_add($e);
-        $c = circular_lshift32!(10, $c);
+        $a = $a.rotate_left($bits).wrapping_add($e);
+        $c = $c.rotate_left(10);
     });
 );
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -162,7 +162,7 @@ impl HashEngine {
             *w_val = util::slice_to_u32_be(buff_bytes);
         }
         for i in 16..80 {
-            w[i] = circular_lshift32!(1, w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]);
+            w[i] =(w[i - 3] ^ w[i - 8] ^ w[i - 14] ^ w[i - 16]).rotate_left(1);
         }
 
         let mut a = self.h[0];
@@ -180,10 +180,10 @@ impl HashEngine {
                 _ => unreachable!()
             };
 
-            let new_a = circular_lshift32!(5, a).wrapping_add(f).wrapping_add(e).wrapping_add(k).wrapping_add(wi);
+            let new_a = a.rotate_left(5).wrapping_add(f).wrapping_add(e).wrapping_add(k).wrapping_add(wi);
             e = d;
             d = c;
-            c = circular_lshift32!(30, b);
+            c = b.rotate_left(30);
             b = a;
             a = new_a;
         }

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -233,9 +233,9 @@ impl hex::FromHex for Midstate {
 
 macro_rules! Ch( ($x:expr, $y:expr, $z:expr) => ($z ^ ($x & ($y ^ $z))) );
 macro_rules! Maj( ($x:expr, $y:expr, $z:expr) => (($x & $y) | ($z & ($x | $y))) );
-macro_rules! Sigma0( ($x:expr) => (circular_lshift32!(30, $x) ^ circular_lshift32!(19, $x) ^ circular_lshift32!(10, $x)) ); macro_rules! Sigma1( ($x:expr) => (circular_lshift32!(26, $x) ^ circular_lshift32!(21, $x) ^ circular_lshift32!(7, $x)) );
-macro_rules! sigma0( ($x:expr) => (circular_lshift32!(25, $x) ^ circular_lshift32!(14, $x) ^ ($x >> 3)) );
-macro_rules! sigma1( ($x:expr) => (circular_lshift32!(15, $x) ^ circular_lshift32!(13, $x) ^ ($x >> 10)) );
+macro_rules! Sigma0( ($x:expr) => ($x.rotate_left(30) ^ $x.rotate_left(19) ^ $x.rotate_left(10)) ); macro_rules! Sigma1( ($x:expr) => ( $x.rotate_left(26) ^ $x.rotate_left(21) ^ $x.rotate_left(7)) );
+macro_rules! sigma0( ($x:expr) => ($x.rotate_left(25) ^ $x.rotate_left(14) ^ ($x >> 3)) );
+macro_rules! sigma1( ($x:expr) => ($x.rotate_left(15) ^ $x.rotate_left(13) ^ ($x >> 10)) );
 
 macro_rules! round(
     // first round

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -212,10 +212,10 @@ impl crate::Hash for Hash {
 
 macro_rules! Ch( ($x:expr, $y:expr, $z:expr) => ($z ^ ($x & ($y ^ $z))) );
 macro_rules! Maj( ($x:expr, $y:expr, $z:expr) => (($x & $y) | ($z & ($x | $y))) );
-macro_rules! Sigma0( ($x:expr) => (circular_lshift64!(36, $x) ^ circular_lshift64!(30, $x) ^ circular_lshift64!(25, $x)) );
-macro_rules! Sigma1( ($x:expr) => (circular_lshift64!(50, $x) ^ circular_lshift64!(46, $x) ^ circular_lshift64!(23, $x)) );
-macro_rules! sigma0( ($x:expr) => (circular_lshift64!(63, $x) ^ circular_lshift64!(56, $x) ^ ($x >> 7)) );
-macro_rules! sigma1( ($x:expr) => (circular_lshift64!(45, $x) ^ circular_lshift64!(3, $x) ^ ($x >> 6)) );
+macro_rules! Sigma0( ($x:expr) => ($x.rotate_left(36) ^ $x.rotate_left(30) ^ $x.rotate_left(25)) );
+macro_rules! Sigma1( ($x:expr) => ($x.rotate_left(50) ^ $x.rotate_left(46) ^ $x.rotate_left(23)) );
+macro_rules! sigma0( ($x:expr) => ($x.rotate_left(63) ^ $x.rotate_left(56) ^ ($x >> 7)) );
+macro_rules! sigma1( ($x:expr) => ($x.rotate_left(45) ^ $x.rotate_left(3) ^ ($x >> 6)) );
 
 macro_rules! round(
     // first round

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,16 +12,6 @@
 // If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 //
 
-/// Circular left-shift a 32-bit word.
-macro_rules! circular_lshift32 (
-    ($shift:expr, $w:expr) => (($w << $shift) | ($w >> (32 - $shift)))
-);
-
-/// Circular left-shift a 64-bit word.
-macro_rules! circular_lshift64 (
-    ($shift:expr, $w:expr) => (($w << $shift) | ($w >> (64 - $shift)))
-);
-
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(


### PR DESCRIPTION
`rotate_left` is now available in our MSRV: https://doc.rust-lang.org/std/primitive.u32.html#method.rotate_left