### PR TITLE
Hack around the broken dyn-clone dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [features]
 default = ["std"]
 std = []
+schemars = ["actual-schemars", "dyn-clone"]
 # If you disable std, you can still use a Write trait via the core2 feature.
 # You can also use ToHex via the alloc feature, as it requires Vec/String.
 # And you can still just disable std by disabling default features, without enabling these two.
@@ -24,10 +25,14 @@ unstable = []  # for benchmarking
 [dependencies]
 # Only enable this if you explicitly do not want to use "std", otherwise enable "serde-std".
 serde = { version = "1.0", default-features = false, optional = true }
-# Can only be used with "std" enabled.
-schemars = { version = "<=0.8.3", optional = true }
 # Only enable this if you explicitly do not want to use an allocator, otherwise enable "alloc".
 core2 = { version = "0.3.0", optional = true, default_features = false }
+
+# Do NOT use this as a feature! Use the `schemars` feature instead. Can only be used with "std" enabled.
+actual-schemars = { package = "schemars", version = "<=0.8.3", optional = true }
+# Do NOT enable this dependency, this is just to pin dyn-clone (transitive dep from schemars)
+# because 1.0.8 does not build with Rust 1.41.1 (because of useage of `Arc::as_ptr`).
+dyn-clone = { version = "<=1.0.7", default_features = false, optional = true }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,8 @@ pub mod _export {
     }
 }
 
-#[cfg(feature = "schemars")] extern crate schemars;
+#[cfg(feature = "schemars")]
+extern crate actual_schemars as schemars;
 
 #[macro_use] mod util;
 #[macro_use] pub mod serde_macros;


### PR DESCRIPTION
The current version of `dyn-clone` v1.0.8 breaks our build (uses `Arc::as_ptr` which only became available in Rust 1.45). 

We can pin the dependency to a version before that works. Requires some toml magic akin to what we do with `actual-serde` in `rust-bitcoin`.