### PR TITLE
Remove `Index` trait bound from `Hash`

### DIFF
--- a/fuzz/fuzz_targets/ripemd160.rs
+++ b/fuzz/fuzz_targets/ripemd160.rs
@@ -15,7 +15,7 @@ fn do_test(data: &[u8]) {
     rc_engine.input(data);
     rc_engine.result(&mut rc_hash);
 
-    assert_eq!(&our_hash[..], &rc_hash[..]);
+    assert_eq!(our_hash.as_ref(), rc_hash.as_ref());
 }
 
 #[cfg(feature = "honggfuzz")]

--- a/fuzz/fuzz_targets/sha1.rs
+++ b/fuzz/fuzz_targets/sha1.rs
@@ -15,7 +15,7 @@ fn do_test(data: &[u8]) {
     rc_sha1.input(data);
     rc_sha1.result(&mut rc_hash);
 
-    assert_eq!(&our_hash[..], &rc_hash[..]);
+    assert_eq!(our_hash.as_ref(), rc_hash.as_ref());
 }
 
 #[cfg(feature = "honggfuzz")]

--- a/fuzz/fuzz_targets/sha256.rs
+++ b/fuzz/fuzz_targets/sha256.rs
@@ -15,7 +15,7 @@ fn do_test(data: &[u8]) {
     rc_engine.input(data);
     rc_engine.result(&mut rc_hash);
 
-    assert_eq!(&our_hash[..], &rc_hash[..]);
+    assert_eq!(our_hash.as_ref(), rc_hash.as_ref());
 }
 
 #[cfg(feature = "honggfuzz")]

--- a/fuzz/fuzz_targets/sha512.rs
+++ b/fuzz/fuzz_targets/sha512.rs
@@ -15,7 +15,7 @@ fn do_test(data: &[u8]) {
     rc_engine.input(data);
     rc_engine.result(&mut rc_hash);
 
-    assert_eq!(&our_hash[..], &rc_hash[..]);
+    assert_eq!(our_hash.as_ref(), rc_hash.as_ref());
 }
 
 #[cfg(feature = "honggfuzz")]

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -91,7 +91,7 @@ mod benches {
         let hash_a = sha256::Hash::hash(&[0; 1]);
         let hash_b = sha256::Hash::hash(&[1; 1]);
         bh.iter(|| {
-            fixed_time_eq(&hash_a[..], &hash_b[..])
+            fixed_time_eq(hash_a.as_ref(), hash_b.as_ref())
         })
     }
 
@@ -100,7 +100,7 @@ mod benches {
         let hash_a = sha256::Hash::hash(&[0; 1]);
         let hash_b = sha256::Hash::hash(&[1; 1]);
         bh.iter(|| {
-            &hash_a[..] == &hash_b[..]
+            hash_a.as_ref() == hash_b.as_ref()
         })
     }
 
@@ -109,7 +109,7 @@ mod benches {
         let hash_a = sha256::Hash::hash(&[0; 1]);
         let hash_b = sha256::Hash::hash(&[0; 1]);
         bh.iter(|| {
-            fixed_time_eq(&hash_a[..], &hash_b[..])
+            fixed_time_eq(hash_a.as_ref(), hash_b.as_ref())
         })
     }
 
@@ -118,7 +118,7 @@ mod benches {
         let hash_a = sha256::Hash::hash(&[0; 1]);
         let hash_b = sha256::Hash::hash(&[0; 1]);
         bh.iter(|| {
-            &hash_a[..] == &hash_b[..]
+            hash_a.as_ref() == hash_b.as_ref()
         })
     }
 
@@ -127,7 +127,7 @@ mod benches {
         let hash_a = sha512::Hash::hash(&[0; 1]);
         let hash_b = sha512::Hash::hash(&[1; 1]);
         bh.iter(|| {
-            fixed_time_eq(&hash_a[..], &hash_b[..])
+            fixed_time_eq(hash_a.as_ref(), hash_b.as_ref())
         })
     }
 
@@ -136,7 +136,7 @@ mod benches {
         let hash_a = sha512::Hash::hash(&[0; 1]);
         let hash_b = sha512::Hash::hash(&[1; 1]);
         bh.iter(|| {
-            &hash_a[..] == &hash_b[..]
+            hash_a.as_ref() == hash_b.as_ref()
         })
     }
 
@@ -145,7 +145,7 @@ mod benches {
         let hash_a = sha512::Hash::hash(&[0; 1]);
         let hash_b = sha512::Hash::hash(&[0; 1]);
         bh.iter(|| {
-            fixed_time_eq(&hash_a[..], &hash_b[..])
+            fixed_time_eq(hash_a.as_ref(), hash_b.as_ref())
         })
     }
 
@@ -154,7 +154,7 @@ mod benches {
         let hash_a = sha512::Hash::hash(&[0; 1]);
         let hash_b = sha512::Hash::hash(&[0; 1]);
         bh.iter(|| {
-            &hash_a[..] == &hash_b[..]
+            hash_a.as_ref() == hash_b.as_ref()
         })
     }
 }

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -21,8 +21,6 @@
 //!
 
 use core::str;
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, hex, ripemd160, sha256};
 
@@ -38,15 +36,6 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl str::FromStr for Hash {
     type Err = hex::Error;
@@ -65,10 +54,10 @@ impl crate::Hash for Hash {
 
     fn from_engine(e: sha256::HashEngine) -> Hash {
         let sha2 = sha256::Hash::from_engine(e);
-        let rmd = ripemd160::Hash::hash(&sha2[..]);
+        let rmd = ripemd160::Hash::hash(sha2.as_ref());
 
         let mut ret = [0; 20];
-        ret.copy_from_slice(&rmd[..]);
+        ret.copy_from_slice(rmd.as_ref());
         Hash(ret)
     }
 
@@ -141,9 +130,9 @@ mod tests {
 
         for test in tests {
             // Hash through high-level API, check hex encoding/decoding
-            let hash = hash160::Hash::hash(&test.input[..]);
+            let hash = hash160::Hash::hash(test.input.as_ref());
             assert_eq!(hash, hash160::Hash::from_hex(test.output_str).expect("parse hex"));
-            assert_eq!(&hash[..], &test.output[..]);
+            assert_eq!(hash.as_ref(), &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte
@@ -153,7 +142,7 @@ mod tests {
             }
             let manual_hash = Hash::from_engine(engine);
             assert_eq!(hash, manual_hash);
-            assert_eq!(hash.into_inner()[..].as_ref(), test.output.as_slice());
+            assert_eq!(hash.into_inner().as_ref(), test.output.as_slice());
         }
     }
 

--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -36,6 +36,7 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 20);
 
 impl str::FromStr for Hash {
     type Err = hex::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@ pub mod siphash24;
 pub mod sha512;
 pub mod cmp;
 
-use core::{borrow, fmt, hash, ops};
+use core::{borrow, convert, fmt, hash};
 
 pub use hmac::{Hmac, HmacEngine};
 pub use error::Error;
@@ -156,14 +156,9 @@ pub trait HashEngine: Clone + Default {
 }
 
 /// Trait which applies to hashes of all types.
-pub trait Hash: Copy + Clone + PartialEq + Eq + PartialOrd + Ord +
-    hash::Hash + fmt::Debug + fmt::Display + fmt::LowerHex +
-    ops::Index<ops::RangeFull, Output = [u8]> +
-    ops::Index<ops::RangeFrom<usize>, Output = [u8]> +
-    ops::Index<ops::RangeTo<usize>, Output = [u8]> +
-    ops::Index<ops::Range<usize>, Output = [u8]> +
-    ops::Index<usize, Output = u8> +
-    borrow::Borrow<[u8]>
+pub trait Hash: Copy + Clone + PartialEq + Eq + PartialOrd + Ord
+    + hash::Hash + fmt::Debug + fmt::Display + fmt::LowerHex
+    + borrow::Borrow<[u8]> + convert::AsRef<[u8]>
 {
     /// A hashing engine which bytes can be serialized into. It is expected
     /// to implement the `io::Write` trait, and to never return errors under
@@ -227,7 +222,7 @@ mod tests {
     fn convert_newtypes() {
         let h1 = TestNewtype::hash(&[]);
         let h2: TestNewtype2 = h1.as_hash().into();
-        assert_eq!(&h1[..], &h2[..]);
+        assert_eq!(h1.as_ref(), h2.as_ref());
 
         let h = sha256d::Hash::hash(&[]);
         let h2: TestNewtype = h.to_string().parse().unwrap();

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -85,6 +85,7 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 20);
 
 impl str::FromStr for Hash {
     type Err = hex::Error;
@@ -516,6 +517,7 @@ mod tests {
             let hash = ripemd160::Hash::hash(&test.input.as_bytes());
             assert_eq!(hash, ripemd160::Hash::from_hex(test.output_str).expect("parse hex"));
             assert_eq!(hash.as_ref(), &test.output[..]);
+            assert_eq!(hash.as_bytes(), &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -22,8 +22,6 @@
 
 use core::{cmp, str};
 use core::convert::TryInto;
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex};
 
@@ -87,15 +85,6 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl str::FromStr for Hash {
     type Err = hex::Error;
@@ -526,7 +515,7 @@ mod tests {
             // Hash through high-level API, check hex encoding/decoding
             let hash = ripemd160::Hash::hash(&test.input.as_bytes());
             assert_eq!(hash, ripemd160::Hash::from_hex(test.output_str).expect("parse hex"));
-            assert_eq!(&hash[..], &test.output[..]);
+            assert_eq!(hash.as_ref(), &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -22,7 +22,7 @@ pub mod serde_details {
     use crate::Error;
 
     use core::marker::PhantomData;
-    use core::{fmt, ops, str};
+    use core::{convert, fmt, str};
     use core::str::FromStr;
     struct HexVisitor<ValueT>(PhantomData<ValueT>);
     use serde::{de, Serializer, Deserializer};
@@ -90,8 +90,7 @@ pub mod serde_details {
         Self: Sized
             + FromStr
             + fmt::Display
-            + ops::Index<usize, Output = u8>
-            + ops::Index<ops::RangeFull, Output = [u8]>,
+            + convert::AsRef<[u8]>,
         <Self as FromStr>::Err: fmt::Display,
     {
         /// Size, in bits, of the hash.
@@ -105,7 +104,7 @@ pub mod serde_details {
             if s.is_human_readable() {
                 s.collect_str(self)
             } else {
-                s.serialize_bytes(&self[..])
+                s.serialize_bytes(self.as_ref())
             }
         }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -17,8 +17,6 @@
 
 use core::{cmp, str};
 use core::convert::TryInto;
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex};
 
@@ -82,15 +80,6 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl str::FromStr for Hash {
     type Err = hex::Error;
@@ -252,7 +241,7 @@ mod tests {
             // Hash through high-level API, check hex encoding/decoding
             let hash = sha1::Hash::hash(&test.input.as_bytes());
             assert_eq!(hash, sha1::Hash::from_hex(test.output_str).expect("parse hex"));
-            assert_eq!(&hash[..], &test.output[..]);
+            assert_eq!(hash.as_ref(), &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -80,6 +80,7 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 20);
 
 impl str::FromStr for Hash {
     type Err = hex::Error;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -87,6 +87,7 @@ impl str::FromStr for Hash {
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 32);
 
 impl crate::Hash for Hash {
     type Engine = HashEngine;
@@ -159,6 +160,7 @@ pub struct Midstate(pub [u8; 32]);
 hex_fmt_impl!(Midstate);
 serde_impl!(Midstate, 32);
 borrow_slice_impl!(Midstate);
+as_bytes_impl!(Midstate, 32);
 
 impl str::FromStr for Midstate {
     type Err = hex::Error;

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -17,8 +17,6 @@
 
 use core::{cmp, str};
 use core::convert::TryInto;
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex};
 
@@ -89,15 +87,6 @@ impl str::FromStr for Hash {
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl crate::Hash for Hash {
     type Engine = HashEngine;
@@ -170,15 +159,6 @@ pub struct Midstate(pub [u8; 32]);
 hex_fmt_impl!(Midstate);
 serde_impl!(Midstate, 32);
 borrow_slice_impl!(Midstate);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Midstate {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl str::FromStr for Midstate {
     type Err = hex::Error;
@@ -259,7 +239,7 @@ impl HashEngine {
         assert!(length % BLOCK_SIZE == 0, "length is no multiple of the block size");
 
         let mut ret = [0; 8];
-        for (ret_val, midstate_bytes) in ret.iter_mut().zip(midstate[..].chunks_exact(4)) {
+        for (ret_val, midstate_bytes) in ret.iter_mut().zip(midstate.as_ref().chunks_exact(4)) {
             *ret_val = u32::from_be_bytes(midstate_bytes.try_into().expect("4 byte slice"));
         }
 
@@ -421,7 +401,7 @@ mod tests {
             // Hash through high-level API, check hex encoding/decoding
             let hash = sha256::Hash::hash(&test.input.as_bytes());
             assert_eq!(hash, sha256::Hash::from_hex(test.output_str).expect("parse hex"));
-            assert_eq!(&hash[..], &test.output[..]);
+            assert_eq!(hash.as_ref(), &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -31,6 +31,7 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 32);
 
 impl str::FromStr for Hash {
     type Err = hex::Error;

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -80,6 +80,7 @@ impl<T: Tag> str::FromStr for Hash<T> {
 
 hex_fmt_impl!(Hash, T:Tag);
 borrow_slice_impl!(Hash, T:Tag);
+as_bytes_impl!(Hash, 32, T:Tag);
 
 impl<T: Tag> crate::Hash for Hash<T> {
     type Engine = sha256::HashEngine;

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -18,8 +18,6 @@
 use core::{cmp, str};
 #[cfg(feature = "serde")] use core::fmt;
 use core::marker::PhantomData;
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, hex, sha256};
 #[cfg(feature="serde")] use crate::Hash as _;
@@ -82,15 +80,6 @@ impl<T: Tag> str::FromStr for Hash<T> {
 
 hex_fmt_impl!(Hash, T:Tag);
 borrow_slice_impl!(Hash, T:Tag);
-
-impl<I: SliceIndex<[u8]>, T: Tag> Index<I> for Hash<T> {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl<T: Tag> crate::Hash for Hash<T> {
     type Engine = sha256::HashEngine;
@@ -170,7 +159,7 @@ impl<T: Tag> serde::Serialize for Hash<T> {
         if s.is_human_readable() {
             s.collect_str(self)
         } else {
-            s.serialize_bytes(&self[..])
+            s.serialize_bytes(self.as_ref())
         }
     }
 }

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -136,6 +136,7 @@ impl str::FromStr for Hash {
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 64);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 64);
 
 impl crate::Hash for Hash {
     type Engine = HashEngine;

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -22,8 +22,6 @@
 
 use core::{cmp, hash, str};
 use core::convert::TryInto;
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex};
 
@@ -138,15 +136,6 @@ impl str::FromStr for Hash {
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 64);
 borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl crate::Hash for Hash {
     type Engine = HashEngine;
@@ -411,7 +400,7 @@ mod tests {
             // Hash through high-level API, check hex encoding/decoding
             let hash = sha512::Hash::hash(&test.input.as_bytes());
             assert_eq!(hash, sha512::Hash::from_hex(test.output_str).expect("parse hex"));
-            assert_eq!(&hash[..], &test.output[..]);
+            assert_eq!(hash.as_ref(), &test.output[..]);
             assert_eq!(&hash.to_hex(), &test.output_str);
 
             // Hash through engine, checking that we can input byte by byte

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -21,8 +21,6 @@
 //!
 
 use core::{cmp, mem, ptr, str};
-use core::ops::Index;
-use core::slice::SliceIndex;
 
 use crate::{Error, Hash as _, HashEngine as _, hex};
 
@@ -206,15 +204,6 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 8);
 borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
 
 impl str::FromStr for Hash {
     type Err = hex::Error;

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -204,6 +204,7 @@ pub struct Hash(
 hex_fmt_impl!(Hash);
 serde_impl!(Hash, 8);
 borrow_slice_impl!(Hash);
+as_bytes_impl!(Hash, 8);
 
 impl str::FromStr for Hash {
     type Err = hex::Error;

--- a/src/util.rs
+++ b/src/util.rs
@@ -58,13 +58,13 @@ macro_rules! borrow_slice_impl(
     ($ty:ident, $($gen:ident: $gent:ident),*) => (
         impl<$($gen: $gent),*> $crate::_export::_core::borrow::Borrow<[u8]> for $ty<$($gen),*>  {
             fn borrow(&self) -> &[u8] {
-                &self[..]
+                self.0.borrow()
             }
         }
 
         impl<$($gen: $gent),*> $crate::_export::_core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
             fn as_ref(&self) -> &[u8] {
-                &self[..]
+                self.0.as_ref()
             }
         }
     )
@@ -189,15 +189,6 @@ macro_rules! hash_newtype {
             type Err = $crate::hex::Error;
             fn from_str(s: &str) -> $crate::_export::_core::result::Result<$newtype, Self::Err> {
                 $crate::hex::FromHex::from_hex(s)
-            }
-        }
-
-        impl<I: $crate::_export::_core::slice::SliceIndex<[u8]>> $crate::_export::_core::ops::Index<I> for $newtype {
-            type Output = I::Output;
-
-            #[inline]
-            fn index(&self, index: I) -> &Self::Output {
-                &self.0[index]
             }
         }
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,9 +28,9 @@ macro_rules! hex_fmt_impl(
                     write!(f, "0x")?;
                 }
                 if $ty::<$($gen),*>::DISPLAY_BACKWARD {
-                    hex::format_hex_reverse(&self.0, f)
+                    hex::format_hex_reverse(self.as_ref(), f)
                 } else {
-                    hex::format_hex(&self.0, f)
+                    hex::format_hex(self.as_ref(), f)
                 }
             }
         }
@@ -65,14 +65,6 @@ macro_rules! borrow_slice_impl(
         impl<$($gen: $gent),*> $crate::_export::_core::convert::AsRef<[u8]> for $ty<$($gen),*>  {
             fn as_ref(&self) -> &[u8] {
                 &self[..]
-            }
-        }
-
-        impl<$($gen: $gent),*> $crate::_export::_core::ops::Deref for $ty<$($gen),*> {
-            type Target = [u8];
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
             }
         }
     )
@@ -243,7 +235,7 @@ mod test {
     fn borrow_slice_impl_to_vec() {
         // Test that the borrow_slice_impl macro gives to_vec.
         let hash = sha256::Hash::hash(&[3, 50]);
-        assert_eq!(hash.to_vec().len(), sha256::Hash::LEN);
+        assert_eq!(hash.as_ref().len(), sha256::Hash::LEN);
     }
 
     hash_newtype!(TestHash, crate::sha256d::Hash, 32, doc="Test hash.");

--- a/src/util.rs
+++ b/src/util.rs
@@ -70,7 +70,7 @@ macro_rules! borrow_slice_impl(
     )
 );
 
-/// Adds a method `as_bytes` to a given type `$ty`.
+/// Adds methods `as_bytes` and `as_mut_bytes` to a given type `$ty`.
 #[macro_export]
 macro_rules! as_bytes_impl(
     ($ty:ident, $len:expr) => (
@@ -81,6 +81,11 @@ macro_rules! as_bytes_impl(
             /// Returns `self` as a byte array reference.
             pub fn as_bytes(&self) -> &[u8; $len] {
                 &self.0
+            }
+
+            /// Returns `self` as a mutable byte array reference.
+            pub fn as_mut_bytes(&mut self) -> &mut [u8; $len] {
+                &mut self.0
             }
         }
     );
@@ -148,6 +153,11 @@ macro_rules! hash_newtype {
             /// Returns `self` as a byte array reference.
             pub fn as_bytes(&self) -> &[u8; $len] {
                 &self.0.as_bytes()
+            }
+
+            /// Returns `self` as a mutable byte array reference.
+            pub fn as_mut_bytes(&mut self) -> &mut [u8; $len] {
+                self.0.as_mut_bytes()
             }
         }
 
@@ -277,6 +287,18 @@ mod test {
     fn lower_hex_alternate() {
         let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
         let got = format!("{:#x}", TestHash::all_zeros());
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn as_mut_bytes() {
+        let mut hash = TestHash::all_zeros();
+        for b in hash.as_mut_bytes().iter_mut() {
+            *b = 0xff;
+        }
+
+        let got = format!("{:#x}", hash);
+        let want = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         assert_eq!(got, want)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -70,6 +70,22 @@ macro_rules! borrow_slice_impl(
     )
 );
 
+/// Adds a method `as_bytes` to a given type `$ty`.
+#[macro_export]
+macro_rules! as_bytes_impl(
+    ($ty:ident, $len:expr) => (
+        $crate::as_bytes_impl!($ty, $len, );
+    );
+    ($ty:ident, $len:expr, $($gen:ident: $gent:ident),*) => (
+        impl<$($gen: $gent),*> $ty<$($gen),*>  {
+            /// Returns `self` as a byte array reference.
+            pub fn as_bytes(&self) -> &[u8; $len] {
+                &self.0
+            }
+        }
+    );
+);
+
 macro_rules! engine_input_impl(
     () => (
         #[cfg(not(fuzzing))]
@@ -127,6 +143,11 @@ macro_rules! hash_newtype {
             pub fn as_hash(&self) -> $hash {
                 // Hashes implement Copy so don't need into_hash.
                 self.0
+            }
+
+            /// Returns `self` as a byte array reference.
+            pub fn as_bytes(&self) -> &[u8; $len] {
+                &self.0.as_bytes()
             }
         }
 


### PR DESCRIPTION
The `Index` trait is not required if we provide the `AsRef` trait. Users
can just call `as_ref()[0]` to get access to the 0th element of a `Hash`.

For times when we take a reference to the whole slice `[..]` using
`as_ref()` is capable and arguably more ergonomic.

From the `Hash` trait remove the trait bound on `Index` and its
associated traits, instead use the trait bound `AsRef` (we already have
a trait bound of `Borrow`).

The first patch removes `Deref` implementations, I did this because
the docs say so - not sure if that is enough justification or if I'm 
missing something.

https://doc.rust-lang.org/std/ops/trait.Deref.html

This work was inspired by https://github.com/rust-bitcoin/rust-miniscript/pull/450#discussion_r932704196

## Verification

This PR is verified to not break usage of the lib by patching `rust-secp256k1` and `rust-bitcoin`.
- https://github.com/rust-bitcoin/rust-secp256k1/pull/482
- https://github.com/rust-bitcoin/rust-bitcoin/pull/1173
