### PR TITLE
Use stdlib integer/slice conversion methods

### DIFF
--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -79,7 +79,7 @@ impl crate::HashEngine for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_20"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_20"))]
     [u8; 20]
 );
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -53,7 +53,7 @@ impl crate::HashEngine for HashEngine {
     #[cfg(not(fuzzing))]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
-        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_exact_mut(4)) {
             ret_bytes.copy_from_slice(&(*val).to_le_bytes());
         }
         ret
@@ -269,7 +269,7 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u32; 16];
-        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(4)) {
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks_exact(4)) {
             *w_val = u32::from_le_bytes(buff_bytes.try_into().expect("4 byte slice"))
         }
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -48,7 +48,7 @@ impl crate::HashEngine for HashEngine {
     #[cfg(not(fuzzing))]
     fn midstate(&self) -> [u8; 20] {
         let mut ret = [0; 20];
-        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_exact_mut(4)) {
             ret_bytes.copy_from_slice(&val.to_be_bytes())
         }
         ret
@@ -157,7 +157,7 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u32; 80];
-        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(4)) {
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks_exact(4)) {
             *w_val = u32::from_be_bytes(buff_bytes.try_into().expect("4 bytes slice"))
         }
         for i in 16..80 {

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -74,7 +74,7 @@ impl crate::HashEngine for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_20"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_20"))]
     [u8; 20]
 );
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -48,7 +48,7 @@ impl crate::HashEngine for HashEngine {
     #[cfg(not(fuzzing))]
     fn midstate(&self) -> Midstate {
         let mut ret = [0; 32];
-        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(4)) {
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_exact_mut(4)) {
             ret_bytes.copy_from_slice(&val.to_be_bytes());
         }
         Midstate(ret)
@@ -259,7 +259,7 @@ impl HashEngine {
         assert!(length % BLOCK_SIZE == 0, "length is no multiple of the block size");
 
         let mut ret = [0; 8];
-        for (ret_val, midstate_bytes) in ret.iter_mut().zip(midstate[..].chunks(4)) {
+        for (ret_val, midstate_bytes) in ret.iter_mut().zip(midstate[..].chunks_exact(4)) {
             *ret_val = u32::from_be_bytes(midstate_bytes.try_into().expect("4 byte slice"));
         }
 
@@ -275,7 +275,7 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u32; 16];
-        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(4)) {
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks_exact(4)) {
             *w_val = u32::from_be_bytes(buff_bytes.try_into().expect("4 byte slice"));
         }
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -74,7 +74,7 @@ impl crate::HashEngine for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_32"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_32"))]
     [u8; 32]
 );
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -56,7 +56,7 @@ impl crate::HashEngine for HashEngine {
     #[cfg(not(fuzzing))]
     fn midstate(&self) -> [u8; 64] {
         let mut ret = [0; 64];
-        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_mut(8)) {
+        for (val, ret_bytes) in self.h.iter().zip(ret.chunks_exact_mut(8)) {
             ret_bytes.copy_from_slice(&val.to_be_bytes());
         }
         ret
@@ -237,7 +237,7 @@ impl HashEngine {
         debug_assert_eq!(self.buffer.len(), BLOCK_SIZE);
 
         let mut w = [0u64; 16];
-        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks(8)) {
+        for (w_val, buff_bytes) in w.iter_mut().zip(self.buffer.chunks_exact(8)) {
             *w_val = u64::from_be_bytes(buff_bytes.try_into().expect("8 byte slice"));
         }
 

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -81,7 +81,7 @@ impl crate::HashEngine for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_64"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_64"))]
     [u8; 64]
 );
 

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -199,7 +199,7 @@ impl crate::HashEngine for HashEngine {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[repr(transparent)]
 pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "util::json_hex_string::len_8"))]
+    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_8"))]
     [u8; 8]
 );
 

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -24,7 +24,7 @@ use core::{cmp, mem, ptr, str};
 use core::ops::Index;
 use core::slice::SliceIndex;
 
-use crate::{Error, Hash as _, HashEngine as _, hex, util};
+use crate::{Error, Hash as _, HashEngine as _, hex};
 
 macro_rules! compress {
     ($state:expr) => {{
@@ -257,12 +257,12 @@ impl Hash {
 
     /// Returns the (little endian) 64-bit integer representation of the hash value.
     pub fn as_u64(&self) -> u64 {
-        util::slice_to_u64_le(&self.0[..])
+        u64::from_le_bytes(self.0)
     }
 
     /// Creates a hash from its (little endian) 64-bit integer representation.
     pub fn from_u64(hash: u64) -> Hash {
-        Hash(util::u64_to_array_le(hash))
+        Hash(hash.to_le_bytes())
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -109,69 +109,6 @@ macro_rules! engine_input_impl(
 
 
 
-macro_rules! define_slice_to_be {
-    ($name: ident, $type: ty) => {
-        #[inline]
-        pub fn $name(slice: &[u8]) -> $type {
-            assert_eq!(slice.len(), core::mem::size_of::<$type>());
-            let mut res = 0;
-            for i in 0..::core::mem::size_of::<$type>() {
-                res |= (slice[i] as $type) << (::core::mem::size_of::<$type>() - i - 1)*8;
-            }
-            res
-        }
-    }
-}
-macro_rules! define_slice_to_le {
-    ($name: ident, $type: ty) => {
-        #[inline]
-        pub fn $name(slice: &[u8]) -> $type {
-            assert_eq!(slice.len(), core::mem::size_of::<$type>());
-            let mut res = 0;
-            for i in 0..::core::mem::size_of::<$type>() {
-                res |= (slice[i] as $type) << i*8;
-            }
-            res
-        }
-    }
-}
-macro_rules! define_be_to_array {
-    ($name: ident, $type: ty, $byte_len: expr) => {
-        #[inline]
-        pub fn $name(val: $type) -> [u8; $byte_len] {
-            assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
-            let mut res = [0; $byte_len];
-            for i in 0..$byte_len {
-                res[i] = ((val >> ($byte_len - i - 1)*8) & 0xff) as u8;
-            }
-            res
-        }
-    }
-}
-macro_rules! define_le_to_array {
-    ($name: ident, $type: ty, $byte_len: expr) => {
-        #[inline]
-        pub fn $name(val: $type) -> [u8; $byte_len] {
-            assert_eq!(::core::mem::size_of::<$type>(), $byte_len); // size_of isn't a constfn in 1.22
-            let mut res = [0; $byte_len];
-            for i in 0..$byte_len {
-                res[i] = ((val >> i*8) & 0xff) as u8;
-            }
-            res
-        }
-    }
-}
-
-define_slice_to_be!(slice_to_u32_be, u32);
-define_slice_to_be!(slice_to_u64_be, u64);
-define_be_to_array!(u32_to_array_be, u32, 4);
-define_be_to_array!(u64_to_array_be, u64, 8);
-
-define_slice_to_le!(slice_to_u32_le, u32);
-define_slice_to_le!(slice_to_u64_le, u64);
-define_le_to_array!(u32_to_array_le, u32, 4);
-define_le_to_array!(u64_to_array_le, u64, 8);
-
 /// Creates a new newtype around a [`Hash`] type.
 #[macro_export]
 macro_rules! hash_newtype {
@@ -302,26 +239,11 @@ pub mod json_hex_string {
 mod test {
     use crate::{Hash, sha256};
 
-    use super::*;
-
     #[test]
     fn borrow_slice_impl_to_vec() {
         // Test that the borrow_slice_impl macro gives to_vec.
         let hash = sha256::Hash::hash(&[3, 50]);
         assert_eq!(hash.to_vec().len(), sha256::Hash::LEN);
-    }
-
-    #[test]
-    fn endianness_test() {
-        assert_eq!(slice_to_u32_be(&[0xde, 0xad, 0xbe, 0xef]), 0xdeadbeef);
-        assert_eq!(slice_to_u64_be(&[0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef]), 0x1badcafedeadbeef);
-        assert_eq!(u32_to_array_be(0xdeadbeef), [0xde, 0xad, 0xbe, 0xef]);
-        assert_eq!(u64_to_array_be(0x1badcafedeadbeef), [0x1b, 0xad, 0xca, 0xfe, 0xde, 0xad, 0xbe, 0xef]);
-
-        assert_eq!(slice_to_u32_le(&[0xef, 0xbe, 0xad, 0xde]), 0xdeadbeef);
-        assert_eq!(slice_to_u64_le(&[0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]), 0x1badcafedeadbeef);
-        assert_eq!(u32_to_array_le(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
-        assert_eq!(u64_to_array_le(0x1badcafedeadbeef), [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]);
     }
 
     hash_newtype!(TestHash, crate::sha256d::Hash, 32, doc="Test hash.");


### PR DESCRIPTION
Now that we have Rust > 1.32 we can use methods on stdlib integers to convert to and from little and big endian slices.

- Patch 1: preparatory cleanup
- Patch 2: do the work
- Patch 3: optimisation, use `chunks_exact`