### PR TITLE
Implement `Debug` and `Display` using `LowerHex`

### DIFF
--- a/src/hash160.rs
+++ b/src/hash160.rs
@@ -35,9 +35,7 @@ pub struct Hash(
     [u8; 20]
 );
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
 

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -83,9 +83,7 @@ pub struct Hash(
     [u8; 20]
 );
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
 

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -78,9 +78,7 @@ pub struct Hash(
     [u8; 20]
 );
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 20);
 borrow_slice_impl!(Hash);
 

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -85,9 +85,7 @@ impl str::FromStr for Hash {
     }
 }
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
 
@@ -168,9 +166,7 @@ impl crate::Hash for Hash {
 #[derive(Copy, Clone, PartialEq, Eq, Default, PartialOrd, Ord, Hash)]
 pub struct Midstate(pub [u8; 32]);
 
-hex_fmt_impl!(Debug, Midstate);
-hex_fmt_impl!(Display, Midstate);
-hex_fmt_impl!(LowerHex, Midstate);
+hex_fmt_impl!(Midstate);
 serde_impl!(Midstate, 32);
 borrow_slice_impl!(Midstate);
 

--- a/src/sha256d.rs
+++ b/src/sha256d.rs
@@ -30,9 +30,7 @@ pub struct Hash(
     [u8; 32]
 );
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 32);
 borrow_slice_impl!(Hash);
 

--- a/src/sha256t.rs
+++ b/src/sha256t.rs
@@ -80,9 +80,7 @@ impl<T: Tag> str::FromStr for Hash<T> {
     }
 }
 
-hex_fmt_impl!(Debug, Hash, T:Tag);
-hex_fmt_impl!(Display, Hash, T:Tag);
-hex_fmt_impl!(LowerHex, Hash, T:Tag);
+hex_fmt_impl!(Hash, T:Tag);
 borrow_slice_impl!(Hash, T:Tag);
 
 impl<I: SliceIndex<[u8]>, T: Tag> Index<I> for Hash<T> {

--- a/src/sha512.rs
+++ b/src/sha512.rs
@@ -134,9 +134,7 @@ impl str::FromStr for Hash {
     }
 }
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 64);
 borrow_slice_impl!(Hash);
 

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -203,9 +203,7 @@ pub struct Hash(
     [u8; 8]
 );
 
-hex_fmt_impl!(Debug, Hash);
-hex_fmt_impl!(Display, Hash);
-hex_fmt_impl!(LowerHex, Hash);
+hex_fmt_impl!(Hash);
 serde_impl!(Hash, 8);
 borrow_slice_impl!(Hash);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -323,4 +323,34 @@ mod test {
         assert_eq!(u32_to_array_le(0xdeadbeef), [0xef, 0xbe, 0xad, 0xde]);
         assert_eq!(u64_to_array_le(0x1badcafedeadbeef), [0xef, 0xbe, 0xad, 0xde, 0xfe, 0xca, 0xad, 0x1b]);
     }
+
+    hash_newtype!(TestHash, crate::sha256d::Hash, 32, doc="Test hash.");
+
+    #[test]
+    fn display() {
+        let want = "0000000000000000000000000000000000000000000000000000000000000000";
+        let got = format!("{}", TestHash::all_zeros());
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn display_alternate() {
+        let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        let got = format!("{:#}", TestHash::all_zeros());
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn lower_hex() {
+        let want = "0000000000000000000000000000000000000000000000000000000000000000";
+        let got = format!("{:x}", TestHash::all_zeros());
+        assert_eq!(got, want)
+    }
+
+    #[test]
+    fn lower_hex_alternate() {
+        let want = "0x0000000000000000000000000000000000000000000000000000000000000000";
+        let got = format!("{:#x}", TestHash::all_zeros());
+        assert_eq!(got, want)
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,20 +15,35 @@
 #[macro_export]
 /// Adds hexadecimal formatting implementation of a trait `$imp` to a given type `$ty`.
 macro_rules! hex_fmt_impl(
-    ($imp:ident, $ty:ident) => (
-        $crate::hex_fmt_impl!($imp, $ty, );
+    ($ty:ident) => (
+        $crate::hex_fmt_impl!($ty, );
     );
-    ($imp:ident, $ty:ident, $($gen:ident: $gent:ident),*) => (
-        impl<$($gen: $gent),*> $crate::_export::_core::fmt::$imp for $ty<$($gen),*> {
+    ($ty:ident, $($gen:ident: $gent:ident),*) => (
+        impl<$($gen: $gent),*> $crate::_export::_core::fmt::LowerHex for $ty<$($gen),*> {
             fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
                 #[allow(unused_imports)]
                 use $crate::{Hash as _, HashEngine as _, hex};
 
+                if f.alternate() {
+                    write!(f, "0x")?;
+                }
                 if $ty::<$($gen),*>::DISPLAY_BACKWARD {
                     hex::format_hex_reverse(&self.0, f)
                 } else {
                     hex::format_hex(&self.0, f)
                 }
+            }
+        }
+
+        impl<$($gen: $gent),*> $crate::_export::_core::fmt::Display for $ty<$($gen),*> {
+            fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                $crate::_export::_core::fmt::LowerHex::fmt(self, f)
+            }
+        }
+
+        impl<$($gen: $gent),*> $crate::_export::_core::fmt::Debug for $ty<$($gen),*> {
+            fn fmt(&self, f: &mut $crate::_export::_core::fmt::Formatter) -> $crate::_export::_core::fmt::Result {
+                write!(f, "{:#}", self)
             }
         }
     );
@@ -169,9 +184,7 @@ macro_rules! hash_newtype {
         #[repr(transparent)]
         pub struct $newtype($hash);
 
-        $crate::hex_fmt_impl!(Debug, $newtype);
-        $crate::hex_fmt_impl!(Display, $newtype);
-        $crate::hex_fmt_impl!(LowerHex, $newtype);
+        $crate::hex_fmt_impl!($newtype);
         $crate::serde_impl!($newtype, $len);
         $crate::borrow_slice_impl!($newtype);
 


### PR DESCRIPTION
Patch 2 adds a unit test that can be moved to before patch 1 to verify this PR does what it claims.

From the commit log of patch 1:

`Display` and `LowerHex` offer an 'alternate' option, hex representations by convention should include `0x` if the alternate format is printed.
    
Currently we implement `Display`, `Debug`, and `LowerHex` all using the same macro. This has two problems, the biggest of which is that we are not correctly handling the alternate format. The second issue is code duplication.
    
Modify the `impl_hex_fmt` macro to implement `LowerHex` (incl. alternate form), then implement `Display` and `Debug` in the macro making calls to `LowerHex`.
