### PR TITLE
Add githooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ This library should always compile with any combination of features on **Rust 1.
 ## Contributions
 
 Contributions are welcome, including additional hash function implementations.
+
+### Githooks
+
+To assist devs in catching errors _before_ running CI we provide some githooks. If you do not
+already have locally configured githooks you can use the ones in this repository by running, in the
+root directory of the repository:
+```
+git config --local core.hooksPath githooks/
+```
+
+Alternatively add symlinks in your `.git/hooks` directory to any of the githooks we provide.

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Verify what is about to be committed. Called by "git commit" with no
+# arguments. The hook should exit with non-zero status after issuing an
+# appropriate message if it wants to stop the commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against -- || exit 1
+
+# Check that code lints cleanly.
+cargo clippy --all-features -- -D warnings || exit 1


### PR DESCRIPTION
As we do in other rust-bitcoin repositories add a `githooks` directory
with a pre-commit hook to catch mistake during development. Add a
section to the readme with instructions on using the githooks.