### PR TITLE
Remove TOOLCHAIN

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -6,12 +6,6 @@ if [ "$DO_ALLOC_TESTS" = true ]; then
 	FEATURES="$FEATURES alloc"
 fi
 
-# Use toolchain if explicitly specified
-if [ -n "$TOOLCHAIN" ]
-then
-    alias cargo="cargo +$TOOLCHAIN"
-fi
-
 cargo --version
 rustc --version
 


### PR DESCRIPTION
Cargo already uses an env var `RUSTUP_TOOLCHAIN` that controls the
toolchain, no need for our custom `TOOLCHAIN` variable.