### PR TITLE
Deduplicate hash types

### DIFF
--- a/src/internal_macros.rs
+++ b/src/internal_macros.rs
@@ -1,0 +1,127 @@
+//! Non-public macros
+
+/// Adds trait impls to the type called `Hash` in the current scope.
+///
+/// Implpements various conversion traits as well as the [`crate::Hash`] trait.
+/// Arguments:
+///
+/// * `$bits` - number of bits this hash type has
+/// * `$reversed` - `bool`  - `true` if the hash type should be displayed backwards, `false`
+///    otherwise.
+/// * `$gen: $gent` - generic type(s) and trait bound(s)
+///
+/// Restrictions on usage:
+///
+/// * There must be a free-standing `fn from_engine(HashEngine) -> Hash` in the scope
+/// * `fn internal_new([u8; $bits / 8]) -> Self` must exist on `Hash`
+/// * `fn internal_engine() -> HashEngine` must exist on `Hash`
+///
+/// `from_engine` obviously implements the finalization algorithm.
+/// `internal_new` is required so that types with more than one field are constructible.
+/// `internal_engine` is required to initialize the engine for given hash type.
+macro_rules! hash_trait_impls {
+    ($bits:expr, $reversed:expr $(, $gen:ident: $gent:ident)*) => {
+        impl<$($gen: $gent),*> str::FromStr for Hash<$($gen),*> {
+            type Err = hex::Error;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                hex::FromHex::from_hex(s)
+            }
+        }
+
+        hex_fmt_impl!(Hash $(, $gen: $gent)*);
+        serde_impl!(Hash, $bits / 8 $(, $gen: $gent)*);
+        borrow_slice_impl!(Hash $(, $gen: $gent)*);
+
+        impl<I: SliceIndex<[u8]> $(, $gen: $gent)*> Index<I> for Hash<$($gen),*> {
+            type Output = I::Output;
+
+            #[inline]
+            fn index(&self, index: I) -> &Self::Output {
+                &self.0[index]
+            }
+        }
+
+        impl<$($gen: $gent),*> crate::Hash for Hash<$($gen),*> {
+            type Engine = HashEngine;
+            type Inner = [u8; $bits / 8];
+
+            const LEN: usize = $bits / 8;
+            const DISPLAY_BACKWARD: bool = $reversed;
+
+            fn engine() -> Self::Engine {
+                Self::internal_engine()
+            }
+
+            fn from_engine(e: HashEngine) -> Hash<$($gen),*> {
+                from_engine(e)
+            }
+
+            fn from_slice(sl: &[u8]) -> Result<Hash<$($gen),*>, Error> {
+                if sl.len() != $bits / 8 {
+                    Err(Error::InvalidLength(Self::LEN, sl.len()))
+                } else {
+                    let mut ret = [0; $bits / 8];
+                    ret.copy_from_slice(sl);
+                    Ok(Self::internal_new(ret))
+                }
+            }
+
+            fn into_inner(self) -> Self::Inner {
+                self.0
+            }
+
+            fn as_inner(&self) -> &Self::Inner {
+                &self.0
+            }
+
+            fn from_inner(inner: Self::Inner) -> Self {
+                Self::internal_new(inner)
+            }
+
+            fn all_zeros() -> Self {
+                Hash::internal_new([0x00; $bits / 8])
+            }
+        }
+    }
+}
+pub(crate) use hash_trait_impls;
+
+/// Creates a type called `Hash` and implements standard interface for it.
+///
+/// The created type will have all standard derives, `Hash` impl and implementation of
+/// `internal_engine` returning default. The created type has a single field.
+///
+/// Arguments:
+///
+/// * `$bits` - the number of bits of the hash type
+/// * `$reversed` - `true` if the hash should be displayed backwards, `false` otherwise
+/// * `$doc` - doc string to put on the type
+/// * `$schemars` - a literal that goes into `schema_with`.
+///
+/// The `from_engine` free-standing function is still required with this macro. See the doc of
+/// [`hash_trait_impls`].
+macro_rules! hash_type {
+    ($bits:expr, $reversed:expr, $doc:literal, $schemars:literal) => {
+        #[doc = $doc]
+        #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(feature = "schemars", derive(crate::schemars::JsonSchema))]
+        #[repr(transparent)]
+        pub struct Hash(
+            #[cfg_attr(feature = "schemars", schemars(schema_with = $schemars))]
+            [u8; $bits / 8]
+        );
+
+        impl Hash {
+            fn internal_new(arr: [u8; $bits / 8]) -> Self {
+                Hash(arr)
+            }
+
+            fn internal_engine() -> HashEngine {
+                Default::default()
+            }
+        }
+
+        crate::internal_macros::hash_trait_impls!($bits, $reversed);
+    }
+}
+pub(crate) use hash_type;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ pub mod _export {
 #[cfg(feature = "schemars")]
 extern crate actual_schemars as schemars;
 
+mod internal_macros;
 #[macro_use] mod util;
 #[macro_use] pub mod serde_macros;
 #[cfg(any(feature = "std", feature = "core2"))] mod impls;

--- a/src/ripemd160.rs
+++ b/src/ripemd160.rs
@@ -27,6 +27,40 @@ use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex};
 
+crate::internal_macros::hash_type! {
+    160,
+    false,
+    "Output of the RIPEMD160 hash function.",
+    "crate::util::json_hex_string::len_20"
+}
+
+#[cfg(not(fuzzing))]
+fn from_engine(mut e: HashEngine) -> Hash {
+    // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
+    let data_len = e.length as u64;
+
+    let zeroes = [0; BLOCK_SIZE - 8];
+    e.input(&[0x80]);
+    if e.length % BLOCK_SIZE > zeroes.len() {
+        e.input(&zeroes);
+    }
+    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
+    e.input(&zeroes[..pad_length]);
+    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
+
+    e.input(&(8 * data_len).to_le_bytes());
+    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
+
+    Hash(e.midstate())
+}
+
+#[cfg(fuzzing)]
+fn from_engine(e: HashEngine) -> Hash {
+    let mut res = e.midstate();
+    res[0] ^= (e.length & 0xff) as u8;
+    Hash(res)
+}
+
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute RIPEMD160 hash function.
@@ -73,95 +107,6 @@ impl crate::HashEngine for HashEngine {
     }
 
     engine_input_impl!();
-}
-
-/// Output of the RIPEMD160 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[repr(transparent)]
-pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_20"))]
-    [u8; 20]
-);
-
-hex_fmt_impl!(Hash);
-serde_impl!(Hash, 20);
-borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl str::FromStr for Hash {
-    type Err = hex::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        hex::FromHex::from_hex(s)
-    }
-}
-
-impl crate::Hash for Hash {
-    type Engine = HashEngine;
-    type Inner = [u8; 20];
-
-    #[cfg(not(fuzzing))]
-    fn from_engine(mut e: HashEngine) -> Hash {
-        // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
-        let data_len = e.length as u64;
-
-        let zeroes = [0; BLOCK_SIZE - 8];
-        e.input(&[0x80]);
-        if e.length % BLOCK_SIZE > zeroes.len() {
-            e.input(&zeroes);
-        }
-        let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
-        e.input(&zeroes[..pad_length]);
-        debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
-
-        e.input(&(8 * data_len).to_le_bytes());
-        debug_assert_eq!(e.length % BLOCK_SIZE, 0);
-
-        Hash(e.midstate())
-    }
-
-    #[cfg(fuzzing)]
-    fn from_engine(e: HashEngine) -> Hash {
-        let mut res = e.midstate();
-        res[0] ^= (e.length & 0xff) as u8;
-        Hash(res)
-    }
-
-    const LEN: usize = 20;
-
-    fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
-        if sl.len() != 20 {
-            Err(Error::InvalidLength(Self::LEN, sl.len()))
-        } else {
-            let mut ret = [0; 20];
-            ret.copy_from_slice(sl);
-            Ok(Hash(ret))
-        }
-    }
-
-    fn into_inner(self) -> Self::Inner {
-        self.0
-    }
-
-    fn as_inner(&self) -> &Self::Inner {
-        &self.0
-    }
-
-    fn from_inner(inner: Self::Inner) -> Self {
-        Hash(inner)
-    }
-
-    fn all_zeros() -> Self {
-        Hash([0x00; 20])
-    }
 }
 
 macro_rules! round(

--- a/src/serde_macros.rs
+++ b/src/serde_macros.rs
@@ -126,8 +126,8 @@ pub mod serde_details {
 #[cfg(feature = "serde")]
 #[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 macro_rules! serde_impl(
-    ($t:ident, $len:expr) => (
-        impl $crate::serde_macros::serde_details::SerdeHash for $t {
+    ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => (
+        impl<$($gen: $gent),*> $crate::serde_macros::serde_details::SerdeHash for $t<$($gen),*> {
             const N : usize = $len;
             fn from_slice_delegated(sl: &[u8]) -> Result<Self, $crate::Error> {
                 #[allow(unused_imports)]
@@ -136,14 +136,14 @@ macro_rules! serde_impl(
             }
         }
 
-        impl $crate::serde::Serialize for $t {
+        impl<$($gen: $gent),*> $crate::serde::Serialize for $t<$($gen),*> {
             fn serialize<S: $crate::serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
                 $crate::serde_macros::serde_details::SerdeHash::serialize(self, s)
             }
         }
 
-        impl<'de> $crate::serde::Deserialize<'de> for $t {
-            fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t, D::Error> {
+        impl<'de $(, $gen: $gent)*> $crate::serde::Deserialize<'de> for $t<$($gen),*> {
+            fn deserialize<D: $crate::serde::Deserializer<'de>>(d: D) -> Result<$t<$($gen),*>, D::Error> {
                 $crate::serde_macros::serde_details::SerdeHash::deserialize(d)
             }
         }
@@ -154,5 +154,5 @@ macro_rules! serde_impl(
 #[cfg(not(feature = "serde"))]
 #[cfg_attr(docsrs, doc(cfg(not(feature = "serde"))))]
 macro_rules! serde_impl(
-        ($t:ident, $len:expr) => ()
+        ($t:ident, $len:expr $(, $gen:ident: $gent:ident)*) => ()
 );

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -22,6 +22,32 @@ use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex};
 
+crate::internal_macros::hash_type! {
+    160,
+    false,
+    "Output of the SHA1 hash function.",
+    "crate::util::json_hex_string::len_20"
+}
+
+fn from_engine(mut e: HashEngine) -> Hash {
+    // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
+    let data_len = e.length as u64;
+
+    let zeroes = [0; BLOCK_SIZE - 8];
+    e.input(&[0x80]);
+    if e.length % BLOCK_SIZE > zeroes.len() {
+        e.input(&zeroes);
+    }
+    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
+    e.input(&zeroes[..pad_length]);
+    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
+
+    e.input(&(8 * data_len).to_be_bytes());
+    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
+
+    Hash(e.midstate())
+}
+
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA1 hash function.
@@ -68,87 +94,6 @@ impl crate::HashEngine for HashEngine {
     }
 
     engine_input_impl!();
-}
-
-/// Output of the SHA1 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[repr(transparent)]
-pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_20"))]
-    [u8; 20]
-);
-
-hex_fmt_impl!(Hash);
-serde_impl!(Hash, 20);
-borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl str::FromStr for Hash {
-    type Err = hex::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        hex::FromHex::from_hex(s)
-    }
-}
-
-impl crate::Hash for Hash {
-    type Engine = HashEngine;
-    type Inner = [u8; 20];
-
-    fn from_engine(mut e: HashEngine) -> Hash {
-        // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
-        let data_len = e.length as u64;
-
-        let zeroes = [0; BLOCK_SIZE - 8];
-        e.input(&[0x80]);
-        if e.length % BLOCK_SIZE > zeroes.len() {
-            e.input(&zeroes);
-        }
-        let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
-        e.input(&zeroes[..pad_length]);
-        debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
-
-        e.input(&(8 * data_len).to_be_bytes());
-        debug_assert_eq!(e.length % BLOCK_SIZE, 0);
-
-        Hash(e.midstate())
-    }
-
-    const LEN: usize = 20;
-
-    fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
-        if sl.len() != 20 {
-            Err(Error::InvalidLength(Self::LEN, sl.len()))
-        } else {
-            let mut ret = [0; 20];
-            ret.copy_from_slice(sl);
-            Ok(Hash(ret))
-        }
-    }
-
-    fn into_inner(self) -> Self::Inner {
-        self.0
-    }
-
-    fn as_inner(&self) -> &Self::Inner {
-        &self.0
-    }
-
-    fn from_inner(inner: Self::Inner) -> Self {
-        Hash(inner)
-    }
-
-    fn all_zeros() -> Self {
-        Hash([0x00; 20])
-    }
 }
 
 impl HashEngine {

--- a/src/sha256.rs
+++ b/src/sha256.rs
@@ -22,6 +22,44 @@ use core::slice::SliceIndex;
 
 use crate::{Error, HashEngine as _, hex, sha256d};
 
+crate::internal_macros::hash_type! {
+    256,
+    false,
+    "Output of the SHA256 hash function.",
+    "crate::util::json_hex_string::len_32"
+}
+
+#[cfg(not(fuzzing))]
+fn from_engine(mut e: HashEngine) -> Hash {
+    // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
+    let data_len = e.length as u64;
+
+    let zeroes = [0; BLOCK_SIZE - 8];
+    e.input(&[0x80]);
+    if e.length % BLOCK_SIZE > zeroes.len() {
+        e.input(&zeroes);
+    }
+    let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
+    e.input(&zeroes[..pad_length]);
+    debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
+
+    e.input(&(8 * data_len).to_be_bytes());
+    debug_assert_eq!(e.length % BLOCK_SIZE, 0);
+
+    Hash(e.midstate().into_inner())
+}
+
+#[cfg(fuzzing)]
+fn from_engine(e: HashEngine) -> Hash {
+    let mut hash = e.midstate().into_inner();
+    if hash == [0; 32] {
+        // Assume sha256 is secure and never generate 0-hashes (which represent invalid
+        // secp256k1 secret keys, causing downstream application breakage).
+        hash[0] = 1;
+    }
+    Hash(hash)
+}
+
 const BLOCK_SIZE: usize = 64;
 
 /// Engine to compute SHA256 hash function.
@@ -70,103 +108,10 @@ impl crate::HashEngine for HashEngine {
     engine_input_impl!();
 }
 
-/// Output of the SHA256 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[repr(transparent)]
-pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_32"))]
-    [u8; 32]
-);
-
 impl Hash {
     /// Iterate the sha256 algorithm to turn a sha256 hash into a sha256d hash
     pub fn hash_again(&self) -> sha256d::Hash {
         crate::Hash::from_inner(<Self as crate::Hash>::hash(&self.0).0)
-    }
-}
-
-impl str::FromStr for Hash {
-    type Err = hex::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        hex::FromHex::from_hex(s)
-    }
-}
-
-hex_fmt_impl!(Hash);
-serde_impl!(Hash, 32);
-borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl crate::Hash for Hash {
-    type Engine = HashEngine;
-    type Inner = [u8; 32];
-
-    #[cfg(not(fuzzing))]
-    fn from_engine(mut e: HashEngine) -> Hash {
-        // pad buffer with a single 1-bit then all 0s, until there are exactly 8 bytes remaining
-        let data_len = e.length as u64;
-
-        let zeroes = [0; BLOCK_SIZE - 8];
-        e.input(&[0x80]);
-        if e.length % BLOCK_SIZE > zeroes.len() {
-            e.input(&zeroes);
-        }
-        let pad_length = zeroes.len() - (e.length % BLOCK_SIZE);
-        e.input(&zeroes[..pad_length]);
-        debug_assert_eq!(e.length % BLOCK_SIZE, zeroes.len());
-
-        e.input(&(8 * data_len).to_be_bytes());
-        debug_assert_eq!(e.length % BLOCK_SIZE, 0);
-
-        Hash(e.midstate().into_inner())
-    }
-
-    #[cfg(fuzzing)]
-    fn from_engine(e: HashEngine) -> Hash {
-        let mut hash = e.midstate().into_inner();
-        if hash == [0; 32] {
-            // Assume sha256 is secure and never generate 0-hashes (which represent invalid
-            // secp256k1 secret keys, causing downstream application breakage).
-            hash[0] = 1;
-        }
-        Hash(hash)
-    }
-
-    const LEN: usize = 32;
-
-    fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
-        if sl.len() != 32 {
-            Err(Error::InvalidLength(Self::LEN, sl.len()))
-        } else {
-            let mut ret = [0; 32];
-            ret.copy_from_slice(sl);
-            Ok(Hash(ret))
-        }
-    }
-
-    fn into_inner(self) -> Self::Inner {
-        self.0
-    }
-
-    fn as_inner(&self) -> &Self::Inner {
-        &self.0
-    }
-
-    fn from_inner(inner: Self::Inner) -> Self {
-        Hash(inner)
-    }
-
-    fn all_zeros() -> Self {
-        Hash([0x00; 32])
     }
 }
 

--- a/src/siphash24.rs
+++ b/src/siphash24.rs
@@ -26,6 +26,25 @@ use core::slice::SliceIndex;
 
 use crate::{Error, Hash as _, HashEngine as _, hex};
 
+crate::internal_macros::hash_type! {
+    64,
+    false,
+    "Output of the SipHash24 hash function.",
+    "crate::util::json_hex_string::len_8"
+}
+
+#[cfg(not(fuzzing))]
+fn from_engine(e: HashEngine) -> Hash {
+    Hash::from_u64(Hash::from_engine_to_u64(e))
+}
+
+#[cfg(fuzzing)]
+fn from_engine(e: HashEngine) -> Hash {
+    let state = e.midstate();
+    Hash::from_u64(state.v0 ^ state.v1 ^ state.v2 ^ state.v3)
+}
+
+
 macro_rules! compress {
     ($state:expr) => {{
         compress!($state.v0, $state.v1, $state.v2, $state.v3)
@@ -194,35 +213,6 @@ impl crate::HashEngine for HashEngine {
 
 }
 
-/// Output of the SipHash24 hash function.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
-#[repr(transparent)]
-pub struct Hash(
-    #[cfg_attr(feature = "schemars", schemars(schema_with = "crate::util::json_hex_string::len_8"))]
-    [u8; 8]
-);
-
-hex_fmt_impl!(Hash);
-serde_impl!(Hash, 8);
-borrow_slice_impl!(Hash);
-
-impl<I: SliceIndex<[u8]>> Index<I> for Hash {
-    type Output = I::Output;
-
-    #[inline]
-    fn index(&self, index: I) -> &Self::Output {
-        &self.0[index]
-    }
-}
-
-impl str::FromStr for Hash {
-    type Err = hex::Error;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        hex::FromHex::from_hex(s)
-    }
-}
-
 impl Hash {
     /// Hashes the given data with an engine with the provided keys.
     pub fn hash_with_keys(k0: u64, k1: u64, data: &[u8]) -> Hash {
@@ -263,50 +253,6 @@ impl Hash {
     /// Creates a hash from its (little endian) 64-bit integer representation.
     pub fn from_u64(hash: u64) -> Hash {
         Hash(hash.to_le_bytes())
-    }
-}
-
-impl crate::Hash for Hash {
-    type Engine = HashEngine;
-    type Inner = [u8; 8];
-
-    #[cfg(not(fuzzing))]
-    fn from_engine(e: HashEngine) -> Hash {
-        Hash::from_u64(Hash::from_engine_to_u64(e))
-    }
-
-    #[cfg(fuzzing)]
-    fn from_engine(e: HashEngine) -> Hash {
-        let state = e.midstate();
-        Hash::from_u64(state.v0 ^ state.v1 ^ state.v2 ^ state.v3)
-    }
-
-    const LEN: usize = 8;
-
-    fn from_slice(sl: &[u8]) -> Result<Hash, Error> {
-        if sl.len() != 8 {
-            Err(Error::InvalidLength(Self::LEN, sl.len()))
-        } else {
-            let mut ret = [0; 8];
-            ret.copy_from_slice(sl);
-            Ok(Hash(ret))
-        }
-    }
-
-    fn into_inner(self) -> Self::Inner {
-        self.0
-    }
-
-    fn as_inner(&self) -> &Self::Inner {
-        &self.0
-    }
-
-    fn from_inner(inner: Self::Inner) -> Self {
-        Hash(inner)
-    }
-
-    fn all_zeros() -> Self {
-        Hash([0x00; 8])
     }
 }
 


### PR DESCRIPTION
There was a lot of code duplicated for all hash types. Most of it
various standard impls. This made it more tedious and error-prone to
modify the impls for all types.

This commit creates two new macros that take care of implementing the
hash types and calls them from each hash module as needed to keep API
and behavior without a change.

This also extends the `serde_impl!` macro to support generics.

This is preparation for upcoming changes.