### PR TITLE
move schemars to separate CI job

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,7 @@ jobs:
           - 1.41.1
           - beta
           - stable
+          - nightly
     steps:
       - name: Checkout Crate
         uses: actions/checkout@v2
@@ -92,8 +93,28 @@ jobs:
       - name: Running cargo
         env:
           DO_FEATURE_MATRIX: true
-          DO_SCHEMARS_TESTS: true
           DO_ALLOC_TESTS: true
+        run: ./contrib/test.sh
+
+  Schemars:
+    name: Schemars Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+    steps:
+      - name: Checkout Crate
+        uses: actions/checkout@v2
+      - name: Checkout Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Running cargo
+        env:
+          DO_SCHEMARS_TESTS: true
         run: ./contrib/test.sh
 
   Embedded:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ since these are needed to display hashes anway.
 ## Minimum Supported Rust Version (MSRV)
 
 This library should always compile with any combination of features on **Rust 1.41.1**.
+The one exception is the `schemars` feature which has no MSRV and should not be used
+by users who expect stability from their libraries.
 
 ## Contributions
 


### PR DESCRIPTION
and run it on nightly only

If it breaks again we'll set it to "allow fail".